### PR TITLE
use dbms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .swp
 *.prof
 happo-agent
+happo-agent.db
 tmp/
 vendor/
 .wercker/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ happo-agent.db
 tmp/
 vendor/
 .wercker/
+debug
+.vscode/

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/metric/status
 
 - key `m-<timestamp>` are metrics(timestamp is unixtime).
     - value: `happo_agent.MetricsData`
-- key `s-<timestamp>` are saved machine state(timestamp is unixtime).
+- key `s-<timestamp>` are saved machine state(timestamp is unixtime). // Future TODO
     - value: `string`
 
 [syndtr/goleveldb: LevelDB key/value database in Go\.](https://github.com/syndtr/goleveldb)

--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/metric/status
 {"capacity":4,"length":4,"newest_timestamp":1454654233,"oldest_timestamp":1454654173}
 ```
 
+## DBMS
+
+- key `m-<timestamp>` are metrics(timestamp is unixtime).
+    - value: `happo_agent.MetricsData`
+- key `s-<timestamp>` are saved machine state(timestamp is unixtime).
+    - value: `string`
+
+[syndtr/goleveldb: LevelDB key/value database in Go\.](https://github.com/syndtr/goleveldb)
+
 ## Contribution
 
 1. Fork ([http://github.com/heartbeatsjp/happo-agent/fork](http://github.com/heartbeatsjp/happo-agent/fork))

--- a/README.md
+++ b/README.md
@@ -254,11 +254,46 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/metric/status
 {"capacity":4,"length":4,"newest_timestamp":1454654233,"oldest_timestamp":1454654173}
 ```
 
+
+### /machine-state/
+
+Get machine state key list.
+
+- Input format
+    - None
+- Input variables
+    - None
+- Return format
+    - JSON
+- Return variables
+    - keys: machine-state key list
+
+```
+$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/machine-state/
+```
+
+### /machine-state/:key
+
+Get machine state.
+
+- Input format
+    - None
+- Input variables
+    - key (can find from `/machine-state/` )
+- Return format
+    - JSON
+- Return variables
+    - machineState: command results
+
+```
+$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/machine-state/s-1498110600
+```
+
 ## DBMS
 
 - key `m-<timestamp>` are metrics(timestamp is unixtime).
     - value: `happo_agent.MetricsData`
-- key `s-<timestamp>` are saved machine state(timestamp is unixtime). // Future TODO
+- key `s-<timestamp>` are saved machine state(timestamp is unixtime).
     - value: `string`
 
 [syndtr/goleveldb: LevelDB key/value database in Go\.](https://github.com/syndtr/goleveldb)

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Get machine state key list.
 
 ```
 $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/machine-state/
+{"keys":["s-1498112479","s-1498112819"]}
 ```
 
 ### /machine-state/:key
@@ -286,7 +287,8 @@ Get machine state.
     - machineState: command results
 
 ```
-$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/machine-state/s-1498110600
+$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/machine-state/s-1498112479
+{"machineState":"********** w (2017-06-22T15:21:19+09:00) cron 15:21:19 up 13 days, ..."}
 ```
 
 ## DBMS

--- a/collect/metrics.go
+++ b/collect/metrics.go
@@ -263,7 +263,8 @@ func GetMetricDataBufferStatus() map[string]int64 {
 	var firstKey, lastKey []byte
 	for iter.Next() {
 		if i == 0 {
-			firstKey = iter.Key()
+			firstKey = make([]byte, len(iter.Key()))
+			copy(firstKey, iter.Key())
 		}
 		lastKey = iter.Key()
 		i = i + 1

--- a/collect/metrics_test.go
+++ b/collect/metrics_test.go
@@ -3,6 +3,7 @@ package collect
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-lib"
@@ -50,6 +51,19 @@ func TestGetCollectedMetrics1(t *testing.T) {
 	ret := GetCollectedMetrics()
 	assert.NotNil(t, ret)
 	assert.Nil(t, GetCollectedMetrics())
+}
+
+func TestGetCollectedMetricsWithLimit1(t *testing.T) {
+	err := Metrics(TEST_CONFIG_FILE)
+	assert.Nil(t, err)
+	time.Sleep(1 * time.Second)
+	err = Metrics(TEST_CONFIG_FILE)
+	assert.Nil(t, err)
+
+	ret := GetCollectedMetricsWithLimit(1)
+	assert.NotNil(t, ret)
+	assert.Equal(t, 1, len(ret))
+	assert.NotNil(t, GetCollectedMetrics())
 }
 
 func TestGetMetrics1(t *testing.T) {

--- a/collect/metrics_test.go
+++ b/collect/metrics_test.go
@@ -1,11 +1,15 @@
 package collect
 
 import (
+	"os"
 	"testing"
 
+	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-lib"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 )
 
 const TEST_CONFIG_FILE = "./metrics_test.yaml"
@@ -45,7 +49,7 @@ func TestGetCollectedMetrics1(t *testing.T) {
 
 	ret := GetCollectedMetrics()
 	assert.NotNil(t, ret)
-	assert.Nil(t, metrics_data_buffer)
+	assert.Nil(t, GetCollectedMetrics())
 }
 
 func TestGetMetrics1(t *testing.T) {
@@ -109,4 +113,16 @@ func TestSaveMetricConfig1(t *testing.T) {
 	config, err := GetMetricConfig(TEST_CONFIG_FILE)
 	assert.EqualValues(t, config, CONFIG_DATA)
 	assert.Nil(t, err)
+}
+
+func TestMain(m *testing.M) {
+	//Mock
+	DB, err := leveldb.Open(storage.NewMemStorage(), nil)
+	if err != nil {
+		os.Exit(1)
+	}
+	db.DB = DB
+	os.Exit(m.Run())
+
+	db.DB.Close()
 }

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -173,6 +173,8 @@ func CmdDaemon(c *cli.Context) {
 	m.Post("/metric", binding.Json(happo_agent.MetricRequest{}), model.Metric)
 	m.Post("/metric/config/update", binding.Json(happo_agent.MetricConfigUpdateRequest{}), model.MetricConfigUpdate)
 	m.Get("/metric/status", model.MetricDataBufferStatus)
+	m.Get("/machine-state/", model.ListMachieState)
+	m.Get("/machine-state/:key", model.GetMachineState)
 
 	// Listener
 	var lis daemonListener

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -158,6 +158,7 @@ func CmdDaemon(c *cli.Context) {
 	dbfile := c.String("dbfile")
 	db.Open(dbfile)
 	defer db.Close()
+	db.MetricsMaxLifetimeSeconds = c.Int64("metrics-max-lifetime-seconds")
 
 	m.Get("/", func() string {
 		return "OK"

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -159,6 +159,7 @@ func CmdDaemon(c *cli.Context) {
 	db.Open(dbfile)
 	defer db.Close()
 	db.MetricsMaxLifetimeSeconds = c.Int64("metrics-max-lifetime-seconds")
+	db.MachineStateMaxLifetimeSeconds = c.Int64("machine-state-max-lifetime-seconds")
 
 	m.Get("/", func() string {
 		return "OK"

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/codegangsta/martini-contrib/secure"
 	"github.com/go-martini/martini"
 	"github.com/heartbeatsjp/happo-agent/collect"
+	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-agent/model"
 	"github.com/heartbeatsjp/happo-agent/util"
 	"github.com/heartbeatsjp/happo-lib"
@@ -153,6 +154,10 @@ func CmdDaemon(c *cli.Context) {
 			}
 		}()
 	}
+
+	dbfile := c.String("dbfile")
+	db.Open(dbfile)
+	defer db.Close()
 
 	m.Get("/", func() string {
 		return "OK"

--- a/commands.go
+++ b/commands.go
@@ -70,6 +70,12 @@ var daemonFlags = []cli.Flag{
 		Usage:  "Metrics Max Lifetime Seconds.",
 		EnvVar: "HAPPO_AGENT_METRICS_MAX_LIFETIME_SECONDS",
 	},
+	cli.Int64Flag{
+		Name:   "machine-state-max-lifetime-seconds",
+		Value:  db.MachineStateMaxLifetimeSeconds,
+		Usage:  "Machine State Max Lifetime Seconds.",
+		EnvVar: "HAPPO_AGENT_MACHINE_STATE_MAX_LIFETIME_SECONDS",
+	},
 }
 
 var Commands = []cli.Command{

--- a/commands.go
+++ b/commands.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/heartbeatsjp/happo-agent/command"
+	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-lib"
 )
 
@@ -65,7 +66,7 @@ var daemonFlags = []cli.Flag{
 	},
 	cli.Int64Flag{
 		Name:   "metrics-max-lifetime-seconds",
-		Value:  7 * 86400,
+		Value:  db.MetricsMaxLifetimeSeconds,
 		Usage:  "Metrics Max Lifetime Seconds.",
 		EnvVar: "HAPPO_AGENT_METRICS_MAX_LIFETIME_SECONDS",
 	},

--- a/commands.go
+++ b/commands.go
@@ -63,6 +63,12 @@ var daemonFlags = []cli.Flag{
 		Usage:  "dbfile",
 		EnvVar: "HAPPO_AGENT_DBFILE",
 	},
+	cli.Int64Flag{
+		Name:   "metrics-max-lifetime-seconds",
+		Value:  7 * 86400,
+		Usage:  "Metrics Max Lifetime Seconds.",
+		EnvVar: "HAPPO_AGENT_METRICS_MAX_LIFETIME_SECONDS",
+	},
 }
 
 var Commands = []cli.Command{

--- a/commands.go
+++ b/commands.go
@@ -57,6 +57,12 @@ var daemonFlags = []cli.Flag{
 		Value: "happo-agent.log",
 		Usage: "logfile.",
 	},
+	cli.StringFlag{
+		Name:   "dbfile, d",
+		Value:  "happo-agent.db",
+		Usage:  "dbfile",
+		EnvVar: "HAPPO_AGENT_DBFILE",
+	},
 }
 
 var Commands = []cli.Command{

--- a/db/db.go
+++ b/db/db.go
@@ -11,6 +11,10 @@ var (
 	MetricsMaxLifetimeSeconds int64
 )
 
+func init() {
+	MetricsMaxLifetimeSeconds = 7 * 86400 //default is 7 days
+}
+
 func Open(dbfile string) {
 	var err error
 	DB, err = leveldb.OpenFile(dbfile, nil)

--- a/db/db.go
+++ b/db/db.go
@@ -7,12 +7,14 @@ import (
 )
 
 var (
-	DB                        *leveldb.DB
-	MetricsMaxLifetimeSeconds int64
+	DB                             *leveldb.DB
+	MetricsMaxLifetimeSeconds      int64
+	MachineStateMaxLifetimeSeconds int64
 )
 
 func init() {
-	MetricsMaxLifetimeSeconds = 7 * 86400 //default is 7 days
+	MetricsMaxLifetimeSeconds = 7 * 86400      //default is 7 days
+	MachineStateMaxLifetimeSeconds = 3 * 86400 //default is 3 days
 }
 
 func Open(dbfile string) {

--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,27 @@
+package db
+
+import (
+	"log"
+
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+var (
+	DB *leveldb.DB
+)
+
+func Open(dbfile string) {
+	var err error
+	DB, err = leveldb.OpenFile(dbfile, nil)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func Close() {
+	var err error
+	err = DB.Close()
+	if err != nil {
+		log.Println(err)
+	}
+}

--- a/db/db.go
+++ b/db/db.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	DB *leveldb.DB
+	DB                        *leveldb.DB
+	MetricsMaxLifetimeSeconds int64
 )
 
 func Open(dbfile string) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 20a62f2722f31eb1bee7866b305e9ecad3384a3294f44cad635d1d2bd684c897
-updated: 2016-09-08T18:07:26.132661246+09:00
+hash: 09b18d12266328804cd5102049aecf3afb2b11152384aecc0544c1c55464432c
+updated: 2017-06-12T14:36:30.109191241+09:00
 imports:
 - name: github.com/client9/reopen
   version: 4b86f9c0ead51cc410d05655596e30f281ed9071
@@ -16,6 +16,8 @@ imports:
   - secure
 - name: github.com/go-martini/martini
   version: 49411a5b646861ad29a6ddd5351717a0a9c49b94
+- name: github.com/golang/snappy
+  version: 553a641470496b2327abcac10b36396bd98e45c9
 - name: github.com/heartbeatsjp/happo-lib
   version: 0506b1206a1b3d6e79fb0394dc6dc465f849dcb0
 - name: github.com/martini-contrib/binding
@@ -24,6 +26,21 @@ imports:
   version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
 - name: github.com/Songmu/timeout
   version: 84831c43cf48f6b1d52c64ed499d714ffd62eca1
+- name: github.com/syndtr/goleveldb
+  version: 8c81ea47d4c41a385645e133e15510fc6a2a74b4
+  subpackages:
+  - leveldb
+  - leveldb/cache
+  - leveldb/comparer
+  - leveldb/errors
+  - leveldb/filter
+  - leveldb/iterator
+  - leveldb/journal
+  - leveldb/memdb
+  - leveldb/opt
+  - leveldb/storage
+  - leveldb/table
+  - leveldb/util
 - name: golang.org/x/net
   version: 9313baa13d9262e49d07b20ed57dceafcd7240cc
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,6 +14,9 @@ import:
   subpackages:
   - netutil
 - package: gopkg.in/yaml.v2
+- package: github.com/syndtr/goleveldb
+  subpackages:
+  - leveldb
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.3

--- a/model/machine_state.go
+++ b/model/machine_state.go
@@ -29,7 +29,7 @@ func ListMachieState(r render.Render) {
 	transaction.Discard()
 
 	if len(keys) == 0 {
-		r.JSON(http.StatusNotFound, nil)
+		r.JSON(http.StatusNotFound, map[string][]string{"keys": []string{}})
 		return
 	}
 	r.JSON(http.StatusOK, map[string][]string{"keys": keys})

--- a/model/machine_state.go
+++ b/model/machine_state.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/codegangsta/martini-contrib/render"
+	"github.com/go-martini/martini"
+	"github.com/heartbeatsjp/happo-agent/db"
+	leveldbUtil "github.com/syndtr/goleveldb/leveldb/util"
+)
+
+func ListMachieState(r render.Render) {
+	transaction, err := db.DB.OpenTransaction()
+	if err != nil {
+		log.Println(err)
+		r.JSON(http.StatusNoContent, map[string]string{"error": err.Error()})
+		return
+	}
+
+	iter := transaction.NewIterator(
+		leveldbUtil.BytesPrefix([]byte("s-")),
+		nil)
+	var keys []string
+	for iter.Next() {
+		keys = append(keys, string(iter.Key()))
+	}
+	iter.Release()
+	transaction.Discard()
+
+	if len(keys) == 0 {
+		r.JSON(http.StatusNotFound, nil)
+		return
+	}
+	r.JSON(http.StatusOK, map[string][]string{"keys": keys})
+}
+
+func GetMachineState(r render.Render, params martini.Params) {
+	key := params["key"]
+
+	val, err := db.DB.Get([]byte(key), nil)
+
+	if err != nil {
+		log.Println(err)
+		r.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+	r.JSON(http.StatusOK, map[string]string{"machineState": string(val)})
+}

--- a/model/metric.go
+++ b/model/metric.go
@@ -14,7 +14,7 @@ var MetricConfigFile string
 func Metric(metric_request happo_agent.MetricRequest, r render.Render) {
 	var metric_response happo_agent.MetricResponse
 
-	metric_response.MetricData = collect.GetCollectedMetricsWithLimit(1440) // FIXME to prefer value. now 1 day = 1440 minutes
+	metric_response.MetricData = collect.GetCollectedMetricsWithLimit(60) // FIXME to prefer value. now 60 times = 1hour
 
 	r.JSON(http.StatusOK, metric_response)
 }

--- a/model/metric.go
+++ b/model/metric.go
@@ -14,7 +14,7 @@ var MetricConfigFile string
 func Metric(metric_request happo_agent.MetricRequest, r render.Render) {
 	var metric_response happo_agent.MetricResponse
 
-	metric_response.MetricData = collect.GetCollectedMetrics()
+	metric_response.MetricData = collect.GetCollectedMetricsWithLimit(1440) // FIXME to prefer value. now 1 day = 1440 minutes
 
 	r.JSON(http.StatusOK, metric_response)
 }


### PR DESCRIPTION
I think happo-agent require too much memory, so store collected metrics to disk.

pros.

- resource usage: reduce required memory size. and keep almost same amount (delayed crawl does not lead to memory consumption)
- data persistent: restart happo-agent does not lead to collected(not crawled) metrics data lost

cons.

- resource usage: disk io
- resource usage: disk space


In future, I think that result of saveState should save in dbms. because wrote out files are unmanaged.