### PR TITLE
new feature: passive metrics collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,29 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/metric --post-data=
 {"metric_data":[{"hostname":"saito-hb-vm101","timestamp":1444028730,"metrics":{"linux.context_switches.context_switches":32662,"linux.disk.elapsed.iotime_sda":52,"linux.disk.elapsed.iotime_weighted_sda":82,"linux.disk.rwtime.tsreading_sda":0,"linux.disk.rwtime.tswriting_sda":82,"linux.forks.forks":88,"linux.interrupts.interrupts":19642,"linux.ss.CLOSE-WAIT":0,"linux.ss.CLOSING":0,"linux.ss.ESTAB":9,"linux.ss.FIN-WAIT-1":0,"linux.ss.FIN-WAIT-2":0,"linux.ss.LAST-ACK":0,"linux.ss.LISTEN":31,"linux.ss.SYN-RECV":0,"linux.ss.SYN-SENT":0,"linux.ss.TIME-WAIT":7,"linux.ss.UNCONN":0,"linux.ss.UNKNOWN":0,"linux.swap.pswpin":0,"linux.swap.pswpout":0,"linux.users.users":1}},…(snip)…],"message":""}
 ```
 
+### /metric/append
+
+Append metric values. (passive metrics collection)
+
+- Input format
+    - JSON
+- Input variables
+    - apikey: ""
+    - MetricData:
+        - (Array)
+            - hostname: Hostname
+            - timestamp: Unix time
+            - metrics: metric name - metric value (key-value)
+- Return format
+    - JSON
+- Return variables
+    - Message: message from agent (if error occurred)
+
+```
+$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/metric/append --post-data='{"apikey": "", {"metric_data":[{"hostname":"saito-hb-vm101","timestamp":1444028730,"metrics":{"linux.context_switches.context_switches":32662,"linux.disk.elapsed.iotime_sda":52,"linux.disk.elapsed.iotime_weighted_sda":82,"linux.disk.rwtime.tsreading_sda":0,"linux.disk.rwtime.tswriting_sda":82,"linux.forks.forks":88,"linux.interrupts.interrupts":19642,"linux.ss.CLOSE-WAIT":0,"linux.ss.CLOSING":0,"linux.ss.ESTAB":9,"linux.ss.FIN-WAIT-1":0,"linux.ss.FIN-WAIT-2":0,"linux.ss.LAST-ACK":0,"linux.ss.LISTEN":31,"linux.ss.SYN-RECV":0,"linux.ss.SYN-SENT":0,"linux.ss.TIME-WAIT":7,"linux.ss.UNCONN":0,"linux.ss.UNKNOWN":0,"linux.swap.pswpin":0,"linux.swap.pswpout":0,"linux.users.users":1}},…(snip)…],"message":""}}'
+{"message": ""}
+```
+
 ### /metric/config/update
 
 *TODO*

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ Append metric values. (passive metrics collection)
     - Message: message from agent (if error occurred)
 
 ```
-$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/metric/append --post-data='{"apikey": "", {"metric_data":[{"hostname":"saito-hb-vm101","timestamp":1444028730,"metrics":{"linux.context_switches.context_switches":32662,"linux.disk.elapsed.iotime_sda":52,"linux.disk.elapsed.iotime_weighted_sda":82,"linux.disk.rwtime.tsreading_sda":0,"linux.disk.rwtime.tswriting_sda":82,"linux.forks.forks":88,"linux.interrupts.interrupts":19642,"linux.ss.CLOSE-WAIT":0,"linux.ss.CLOSING":0,"linux.ss.ESTAB":9,"linux.ss.FIN-WAIT-1":0,"linux.ss.FIN-WAIT-2":0,"linux.ss.LAST-ACK":0,"linux.ss.LISTEN":31,"linux.ss.SYN-RECV":0,"linux.ss.SYN-SENT":0,"linux.ss.TIME-WAIT":7,"linux.ss.UNCONN":0,"linux.ss.UNKNOWN":0,"linux.swap.pswpin":0,"linux.swap.pswpout":0,"linux.users.users":1}},…(snip)…],"message":""}}'
-{"message": ""}
+$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/metric/append --post-data='{"apikey": "", "metric_data":[{"hostname":"saito-hb-vm101","timestamp":1444028730,"metrics":{"linux.context_switches.context_switches":32662,"linux.disk.elapsed.iotime_sda":52,"linux.disk.elapsed.iotime_weighted_sda":82,"linux.disk.rwtime.tsreading_sda":0,"linux.disk.rwtime.tswriting_sda":82,"linux.forks.forks":88,"linux.interrupts.interrupts":19642,"linux.ss.CLOSE-WAIT":0,"linux.ss.CLOSING":0,"linux.ss.ESTAB":9,"linux.ss.FIN-WAIT-1":0,"linux.ss.FIN-WAIT-2":0,"linux.ss.LAST-ACK":0,"linux.ss.LISTEN":31,"linux.ss.SYN-RECV":0,"linux.ss.SYN-SENT":0,"linux.ss.TIME-WAIT":7,"linux.ss.UNCONN":0,"linux.ss.UNKNOWN":0,"linux.swap.pswpin":0,"linux.swap.pswpout":0,"linux.users.users":1}},...(snip)...]}'
+{"status": "ok", "message": ""}
 ```
 
 ### /metric/config/update

--- a/collect/metrics.go
+++ b/collect/metrics.go
@@ -16,6 +16,7 @@ import (
 	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-agent/util"
 	"github.com/heartbeatsjp/happo-lib"
+	leveldbErrors "github.com/syndtr/goleveldb/leveldb/errors"
 	leveldbUtil "github.com/syndtr/goleveldb/leveldb/util"
 
 	"gopkg.in/yaml.v2"
@@ -42,7 +43,7 @@ func Metrics(config_path string) error {
 			} else if raw_metrics == "" {
 				continue
 			}
-			metric_data, timestamp, err := parseMetricData(raw_metrics)
+			metric_data, timestamp, err := ParseMetricData(raw_metrics)
 			if err != nil {
 				return err
 			}
@@ -55,7 +56,12 @@ func Metrics(config_path string) error {
 		}
 	}
 
-	now := time.Now()
+	err = SaveMetrics(time.Now(), metrics_data_buffer)
+	return err
+}
+
+//SaveMetrics save metrics to dbms
+func SaveMetrics(timestamp time.Time, metricsData []happo_agent.MetricsData) error {
 
 	// Save Metrics
 	transaction, err := db.DB.OpenTransaction()
@@ -63,14 +69,24 @@ func Metrics(config_path string) error {
 		log.Println(err)
 	}
 
+	value, err := transaction.Get(
+		[]byte(fmt.Sprintf("m-%d", timestamp.Unix())),
+		nil)
+	if err != leveldbErrors.ErrNotFound {
+		savedMetricsData := []happo_agent.MetricsData{}
+		dec := gob.NewDecoder(bytes.NewReader(value))
+		dec.Decode(&savedMetricsData)
+		metricsData = append(savedMetricsData, metricsData...)
+	}
+
 	var b bytes.Buffer
 	enc := gob.NewEncoder(&b)
-	err = enc.Encode(metrics_data_buffer)
+	err = enc.Encode(metricsData)
 	if err != nil {
 		log.Println(err)
 	} else {
 		transaction.Put(
-			[]byte(fmt.Sprintf("m-%d", now.Unix())),
+			[]byte(fmt.Sprintf("m-%d", timestamp.Unix())),
 			b.Bytes(),
 			nil)
 	}
@@ -86,7 +102,7 @@ func Metrics(config_path string) error {
 	if err != nil {
 		log.Println(err)
 	}
-	oldestThreshold := now.Add(time.Duration(-1*db.MetricsMaxLifetimeSeconds) * time.Second)
+	oldestThreshold := timestamp.Add(time.Duration(-1*db.MetricsMaxLifetimeSeconds) * time.Second)
 	iter := transaction.NewIterator(
 		&leveldbUtil.Range{
 			Start: []byte("m-0"),
@@ -99,10 +115,10 @@ func Metrics(config_path string) error {
 
 		// logging
 		unixTime, _ := strconv.Atoi(strings.SplitN(string(key), "-", 2)[1])
-		metricsData := []happo_agent.MetricsData{}
+		deletedMetricsData := []happo_agent.MetricsData{}
 		dec := gob.NewDecoder(bytes.NewReader(value))
-		dec.Decode(&metricsData)
-		log.Printf("retire old metrics: key=%v(%v), value=%v\n", string(key), time.Unix(int64(unixTime), 0), metricsData)
+		dec.Decode(&deletedMetricsData)
+		log.Printf("retire old metrics: key=%v(%v), value=%v\n", string(key), time.Unix(int64(unixTime), 0), deletedMetricsData)
 	}
 	iter.Release()
 
@@ -203,7 +219,7 @@ func getMetrics(plugin_name string, plugin_option string) (string, error) {
 }
 
 // Sensu形式のメトリックをパースします
-func parseMetricData(raw_metricdata string) (map[string]float64, int64, error) {
+func ParseMetricData(raw_metricdata string) (map[string]float64, int64, error) {
 	var timestamp int64 = 0
 	results := make(map[string]float64)
 

--- a/collect/metrics.go
+++ b/collect/metrics.go
@@ -298,7 +298,8 @@ func GetMetricDataBufferStatus() map[string]int64 {
 			firstKey = make([]byte, len(iter.Key()))
 			copy(firstKey, iter.Key())
 		}
-		lastKey = iter.Key()
+		lastKey = make([]byte, len(iter.Key()))
+		copy(lastKey, iter.Key())
 		i = i + 1
 	}
 	iter.Release()

--- a/collect/metrics.go
+++ b/collect/metrics.go
@@ -115,10 +115,10 @@ func SaveMetrics(timestamp time.Time, metricsData []happo_agent.MetricsData) err
 
 		// logging
 		unixTime, _ := strconv.Atoi(strings.SplitN(string(key), "-", 2)[1])
-		deletedMetricsData := []happo_agent.MetricsData{}
+		expired := []happo_agent.MetricsData{}
 		dec := gob.NewDecoder(bytes.NewReader(value))
-		dec.Decode(&deletedMetricsData)
-		log.Printf("retire old metrics: key=%v(%v), value=%v\n", string(key), time.Unix(int64(unixTime), 0), deletedMetricsData)
+		dec.Decode(&expired)
+		log.Printf("retire old metrics: key=%v(%v), value=%v\n", string(key), time.Unix(int64(unixTime), 0), expired)
 	}
 	iter.Release()
 

--- a/collect/metrics_test.go
+++ b/collect/metrics_test.go
@@ -81,14 +81,14 @@ func TestGetMetrics2(t *testing.T) {
 func TestParseMetricData1(t *testing.T) {
 	RET_ASSERT := map[string]float64{"hoge": 10}
 
-	ret, timestamp, err := parseMetricData("hoge	10	1")
+	ret, timestamp, err := ParseMetricData("hoge	10	1")
 	assert.EqualValues(t, ret, RET_ASSERT)
 	assert.EqualValues(t, timestamp, 1)
 	assert.Nil(t, err)
 }
 
 func TestParseMetricData2(t *testing.T) {
-	ret, timestamp, err := parseMetricData("hoge	foo	bar")
+	ret, timestamp, err := ParseMetricData("hoge	foo	bar")
 	assert.Nil(t, ret)
 	assert.EqualValues(t, timestamp, 0)
 	assert.NotNil(t, err)
@@ -97,7 +97,7 @@ func TestParseMetricData2(t *testing.T) {
 func TestParseMetricData3(t *testing.T) {
 	RET_ASSERT := map[string]float64{}
 
-	ret, timestamp, err := parseMetricData("hoge")
+	ret, timestamp, err := ParseMetricData("hoge")
 	assert.EqualValues(t, ret, RET_ASSERT)
 	assert.EqualValues(t, timestamp, 0)
 	assert.Nil(t, err)
@@ -127,6 +127,70 @@ func TestSaveMetricConfig1(t *testing.T) {
 	config, err := GetMetricConfig(TEST_CONFIG_FILE)
 	assert.EqualValues(t, config, CONFIG_DATA)
 	assert.Nil(t, err)
+}
+
+func TestSaveMetrics1(t *testing.T) {
+	var err error
+	metricsData1 := []happo_agent.MetricsData{
+		happo_agent.MetricsData{Host_Name: "host1", Timestamp: 101, Metrics: map[string]float64{"val1": 111, "val2": 112}},
+		happo_agent.MetricsData{Host_Name: "host1", Timestamp: 102, Metrics: map[string]float64{"val1": 121, "val2": 122}},
+	}
+	metricsData2 := []happo_agent.MetricsData{
+		happo_agent.MetricsData{Host_Name: "host2", Timestamp: 101, Metrics: map[string]float64{"val1": 211, "val2": 212}},
+		happo_agent.MetricsData{Host_Name: "host2", Timestamp: 102, Metrics: map[string]float64{"val1": 221, "val2": 222}},
+	}
+
+	err = SaveMetrics(time.Unix(1001, 0), metricsData1)
+	assert.Nil(t, err)
+	got := GetCollectedMetricsWithLimit(-1)
+	assert.Equal(t, got, metricsData1)
+
+	err = SaveMetrics(time.Unix(1002, 0), metricsData2)
+	assert.Nil(t, err)
+	got = GetCollectedMetricsWithLimit(-1)
+	assert.Equal(t, got, metricsData2)
+}
+
+func TestSaveMetrics2(t *testing.T) {
+	var err error
+	metricsData1 := []happo_agent.MetricsData{
+		happo_agent.MetricsData{Host_Name: "host1", Timestamp: 101, Metrics: map[string]float64{"val1": 111, "val2": 112}},
+		happo_agent.MetricsData{Host_Name: "host1", Timestamp: 102, Metrics: map[string]float64{"val1": 121, "val2": 122}},
+	}
+	metricsData2 := []happo_agent.MetricsData{
+		happo_agent.MetricsData{Host_Name: "host2", Timestamp: 101, Metrics: map[string]float64{"val1": 211, "val2": 212}},
+		happo_agent.MetricsData{Host_Name: "host2", Timestamp: 102, Metrics: map[string]float64{"val1": 221, "val2": 222}},
+	}
+
+	err = SaveMetrics(time.Unix(1001, 0), metricsData1)
+	assert.Nil(t, err)
+
+	err = SaveMetrics(time.Unix(1002, 0), metricsData2)
+	assert.Nil(t, err)
+
+	got := GetCollectedMetricsWithLimit(-1)
+	assert.Equal(t, got, append(metricsData1, metricsData2...))
+}
+
+func TestSaveMetrics3(t *testing.T) {
+	var err error
+	metricsData1 := []happo_agent.MetricsData{
+		happo_agent.MetricsData{Host_Name: "host1", Timestamp: 101, Metrics: map[string]float64{"val1": 111, "val2": 112}},
+		happo_agent.MetricsData{Host_Name: "host1", Timestamp: 102, Metrics: map[string]float64{"val1": 121, "val2": 122}},
+	}
+	metricsData2 := []happo_agent.MetricsData{
+		happo_agent.MetricsData{Host_Name: "host2", Timestamp: 201, Metrics: map[string]float64{"val1": 211, "val2": 212}},
+		happo_agent.MetricsData{Host_Name: "host2", Timestamp: 202, Metrics: map[string]float64{"val1": 221, "val2": 222}},
+	}
+
+	err = SaveMetrics(time.Unix(1000, 0), metricsData1)
+	assert.Nil(t, err)
+
+	err = SaveMetrics(time.Unix(1000, 0), metricsData2)
+	assert.Nil(t, err)
+
+	got := GetCollectedMetricsWithLimit(-1)
+	assert.Equal(t, got, append(metricsData1, metricsData2...))
 }
 
 func TestMain(m *testing.M) {

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -172,10 +172,7 @@ func CmdDaemon(c *cli.Context) {
 	m.Post("/inventory", binding.Json(happo_agent.InventoryRequest{}), model.Inventory)
 	m.Post("/monitor", binding.Json(happo_agent.MonitorRequest{}), model.Monitor)
 	m.Post("/metric", binding.Json(happo_agent.MetricRequest{}), model.Metric)
-	m.Post("/metric/append", binding.Json(struct {
-		Api_Key    string                    `json:"apikey"`
-		MetricData []happo_agent.MetricsData `json:"metric_data"`
-	}{}), model.MetricAppend)
+	m.Post("/metric/append", binding.Json(happo_agent.MetricAppendRequest{}), model.MetricAppend)
 	m.Post("/metric/config/update", binding.Json(happo_agent.MetricConfigUpdateRequest{}), model.MetricConfigUpdate)
 	m.Get("/metric/status", model.MetricDataBufferStatus)
 	m.Get("/machine-state/", model.ListMachieState)

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -172,6 +172,10 @@ func CmdDaemon(c *cli.Context) {
 	m.Post("/inventory", binding.Json(happo_agent.InventoryRequest{}), model.Inventory)
 	m.Post("/monitor", binding.Json(happo_agent.MonitorRequest{}), model.Monitor)
 	m.Post("/metric", binding.Json(happo_agent.MetricRequest{}), model.Metric)
+	m.Post("/metric/append", binding.Json(struct {
+		Api_Key    string                    `json:"apikey"`
+		MetricData []happo_agent.MetricsData `json:"metric_data"`
+	}{}), model.MetricAppend)
 	m.Post("/metric/config/update", binding.Json(happo_agent.MetricConfigUpdateRequest{}), model.MetricConfigUpdate)
 	m.Get("/metric/status", model.MetricDataBufferStatus)
 	m.Get("/machine-state/", model.ListMachieState)

--- a/command/metric.go
+++ b/command/metric.go
@@ -54,11 +54,7 @@ func CmdAppendMetric(c *cli.Context) error {
 		return nil
 	}
 
-	//var metricAppendRequest happo_agent.MetricAppendRequest  //TODO
-	var metricAppendRequest struct {
-		Api_Key    string                    `json:"apikey"`
-		MetricData []happo_agent.MetricsData `json:"metric_data"`
-	}
+	var metricAppendRequest happo_agent.MetricAppendRequest
 
 	metricAppendRequest.Api_Key = c.String("api-key")
 	metricAppendRequest.MetricData = metricsDataSlice

--- a/command/metric.go
+++ b/command/metric.go
@@ -1,0 +1,81 @@
+package command
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/heartbeatsjp/happo-agent/collect"
+	"github.com/heartbeatsjp/happo-agent/util"
+	"github.com/heartbeatsjp/happo-lib"
+)
+
+//CmdAppendMetric is action of subcommand append_metric
+func CmdAppendMetric(c *cli.Context) error {
+	var err error
+
+	hostname := c.String("hostname")
+	bastionEndoint := c.String("bastion-endpoint")
+	datafileArg := c.String("datafile")
+	dryRun := c.Bool("dry-run")
+
+	var f *os.File
+	defer f.Close()
+	if datafileArg == "-" {
+		f = os.Stdin
+	} else {
+		f, err = os.Open(datafileArg)
+		if err != nil {
+			return err
+		}
+	}
+
+	var metricsDataSlice []happo_agent.MetricsData
+	read, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	metricData, timestamp, err := collect.ParseMetricData(string(read))
+	if err != nil {
+		return err
+	}
+
+	var m happo_agent.MetricsData
+	m.Host_Name = hostname
+	m.Timestamp = timestamp
+	m.Metrics = metricData
+	metricsDataSlice = append(metricsDataSlice, m)
+
+	if dryRun {
+		log.Println(metricsDataSlice)
+		return nil
+	}
+
+	//var metricAppendRequest happo_agent.MetricAppendRequest  //TODO
+	var metricAppendRequest struct {
+		Api_Key    string                    `json:"apikey"`
+		MetricData []happo_agent.MetricsData `json:"metric_data"`
+	}
+
+	metricAppendRequest.Api_Key = c.String("api-key")
+	metricAppendRequest.MetricData = metricsDataSlice
+
+	data, err := json.Marshal(metricAppendRequest)
+	if err != nil {
+		return err
+	}
+
+	resp, err := util.RequestToMetricAppendAPI(bastionEndoint, data)
+	if err != nil && resp == nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.Fatal(resp)
+	}
+	log.Printf("Success.")
+
+	return nil
+}

--- a/commands.go
+++ b/commands.go
@@ -175,6 +175,41 @@ var Commands = []cli.Command{
 			},
 		},
 	},
+	{
+		Name:   "append_metric",
+		Usage:  "Append Metric.",
+		Action: command.CmdAppendMetric,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   "hostname, H",
+				Usage:  "Hostname",
+				EnvVar: "HAPPO_AGENT_HOSTNAME",
+			},
+			cli.StringFlag{
+				Name:   "bastion-endpoint, b",
+				Value:  "https://127.0.0.1:6777",
+				Usage:  "Bastion (Nearby happo-agent) endpoint address",
+				EnvVar: "HAPPO_AGENT_BASTION_ENDPOINT",
+			},
+			cli.StringFlag{
+				Name:   "datafile",
+				Value:  "-",
+				Usage:  "sensu format datafile(default: - (stdin))",
+				EnvVar: "HAPPO_AGENT_DATAFILE",
+			},
+			cli.StringFlag{
+				Name:   "api-key, a",
+				Value:  "",
+				Usage:  "API Key",
+				EnvVar: "HAPPO_AGENT_API_KEY",
+			},
+			cli.BoolFlag{
+				Name:   "dry-run, n",
+				Usage:  "dry run(NOT post to bastion)",
+				EnvVar: "HAPPO_AGENT_DRY_RUN",
+			},
+		},
+	},
 }
 
 func CommandNotFound(c *cli.Context, command string) {

--- a/glide.lock
+++ b/glide.lock
@@ -19,7 +19,7 @@ imports:
 - name: github.com/golang/snappy
   version: 553a641470496b2327abcac10b36396bd98e45c9
 - name: github.com/heartbeatsjp/happo-lib
-  version: 0506b1206a1b3d6e79fb0394dc6dc465f849dcb0
+  version: 8bbc8b27737ec591aa70ab607ea85dcaf980ee82
 - name: github.com/martini-contrib/binding
   version: 05d3e151b6cf34dacac6306226a33db68459a3b5
 - name: github.com/Sirupsen/logrus

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,7 +8,7 @@ import:
 - package: github.com/go-martini/martini
   version: ^1.0.0
 - package: github.com/heartbeatsjp/happo-lib
-  version: ^0.9.3
+  version: ^0.9.6
 - package: github.com/martini-contrib/binding
 - package: golang.org/x/net
   subpackages:

--- a/model/metric.go
+++ b/model/metric.go
@@ -21,16 +21,8 @@ func Metric(metric_request happo_agent.MetricRequest, r render.Render) {
 }
 
 //MetricAppend store metrics to local dbms
-func MetricAppend(request struct {
-	Api_Key    string                    `json:"apikey"`
-	MetricData []happo_agent.MetricsData `json:"metric_data"`
-}, // happo_agent.MetricsAppendRequest //TODO
-	r render.Render) {
-	//var response happo_agent.MetricAppendResponse  // TODO
-	var response struct {
-		Status  string `json:"status"`
-		Message string `json:"message"`
-	}
+func MetricAppend(request happo_agent.MetricAppendRequest, r render.Render) {
+	var response happo_agent.MetricAppendResponse
 
 	err := collect.SaveMetrics(time.Now(), request.MetricData)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -108,10 +108,18 @@ func RequestToManageAPI(endpoint string, path string, postdata []byte) (*http.Re
 }
 
 func RequestToMetricAppendAPI(endpoint string, postdata []byte) (*http.Response, error) {
+	client, req, err := buildMetricAppendAPIRequest(endpoint, postdata)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+func buildMetricAppendAPIRequest(endpoint string, postdata []byte) (*http.Client, *http.Request, error) {
 	uri := fmt.Sprintf("%s/metric/append", endpoint)
 	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(postdata))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
@@ -119,6 +127,5 @@ func RequestToMetricAppendAPI(endpoint string, postdata []byte) (*http.Response,
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}
-
-	return client.Do(req)
+	return client, req, err
 }

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -104,4 +105,20 @@ func RequestToManageAPI(endpoint string, path string, postdata []byte) (*http.Re
 	req.Header.Set("Content-Type", "application/json")
 
 	return http.DefaultTransport.RoundTrip(req)
+}
+
+func RequestToMetricAppendAPI(endpoint string, postdata []byte) (*http.Response, error) {
+	uri := fmt.Sprintf("%s/metric/append", endpoint)
+	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(postdata))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	//FIXME other parameters should be proper values
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	return client.Do(req)
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/heartbeatsjp/happo-lib"
@@ -79,5 +80,33 @@ func TestExecCommand4(t *testing.T) {
 	exit_code, out, err := ExecCommandCombinedOutput(command, option)
 	assert.EqualValues(t, exit_code, 0)
 	assert.Contains(t, out, "1.STDOUT.2.STDERR.3.STDOUT.4.STDERR.")
+	assert.Nil(t, err)
+}
+
+func TestBuildMetricAppendAPIRequest1(t *testing.T) {
+	client, req, err := buildMetricAppendAPIRequest("https://127.0.0.2:6777", []byte(
+		`{
+		"api_key": "asdf",
+		"metric_data":[
+		{ "hostname":"saito-hb-vm101",
+		"timestamp":1444028731,
+		"metrics": {"linux.context_switches.context_switches":10001,
+		"linux.disk.elapsed.iotime_sda":11,
+		"linux.disk.elapsed.iotime_weighted_sda":111 }
+	},
+	{ "hostname":"saito-hb-vm102",
+	"timestamp":1444028732,
+	"metrics":{
+		"linux.context_switches.context_switches":20002,
+		"linux.disk.elapsed.iotime_sda":22,
+		"linux.disk.elapsed.iotime_weighted_sda":222 }
+	}
+	]}`))
+	assert.True(t, (client.Transport.(*http.Transport)).TLSClientConfig.InsecureSkipVerify)
+	assert.Equal(t, req.URL.Scheme, "https")
+	assert.Equal(t, req.URL.Host, "127.0.0.2:6777")
+	assert.Equal(t, req.URL.Path, "/metric/append")
+	assert.Equal(t, req.Method, "POST")
+	assert.Equal(t, req.Header.Get("Content-Type"), "application/json")
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Passive metrics collection feature.

- [x] endpoint( `/metric/append` )
- [x] subcommand `append_metric`
    - ex: `some_sensu_format_command | happo-agent append_metric --hostname $(uname -n) --endpoint <NEARBY_HAPPO_AGENT>`