### PR TITLE
change timeout status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Use agent bastion(proxy) mode.
 - Return variables
     - By `request_type` type.
 
+In case `--proxy-timeout-seconds` reached, return `504 Gateway Timeout` .
+
 ```
 $ wget -q --no-check-certificate -O - https://192.0.2.1:6777/proxy --post-data='{"proxy_hostport": ["198.51.100.1:6777"], "request_type": "monitor", "request_json": "{\"apikey\": \"\", \"plugin_name\": \"check_procs\", \"plugin_option\": \"-w 100 -c 200\"}"}'
 {"return_value":1,"message":"PROCS WARNING: 168 processes\n"}
@@ -200,6 +202,8 @@ Call monitor plugin. It likes nrpe.
 - Return variables
     - return\_code: commands return code
     - return\_value: commands return value (stdout, stderr)
+
+In case `--command-timeout` reached, return `503 Service Unavailable` .
 
 ```
 $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/monitor --post-data='{"apikey": "", "plugin_name": "check_procs", "plugin_option": "-w 100 -c 200"}'

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -33,7 +33,7 @@ import (
 
 // --- Struct
 type daemonListener struct {
-	Timeout        int
+	Timeout        int //second
 	MaxConnections int
 	Port           string
 	Handler        http.Handler
@@ -185,6 +185,12 @@ func CmdDaemon(c *cli.Context) {
 	lis.Port = fmt.Sprintf(":%d", c.Int("port"))
 	lis.Handler = m
 	lis.Timeout = happo_agent.HTTP_TIMEOUT
+	if lis.Timeout < int(c.Int64("proxy-timeout-seconds")) {
+		lis.Timeout = int(c.Int64("proxy-timeout-seconds"))
+	}
+	if lis.Timeout < c.Int("command-timeout") {
+		lis.Timeout = c.Int("command-timeout")
+	}
 	lis.MaxConnections = c.Int("max-connections")
 	lis.PublicKey = c.String("public-key")
 	lis.PrivateKey = c.String("private-key")
@@ -241,8 +247,8 @@ func (l *daemonListener) listenAndServe() error {
 		TLSConfig:    tls_config,
 		Addr:         l.Port,
 		Handler:      l.Handler,
-		ReadTimeout:  happo_agent.HTTP_TIMEOUT * time.Second,
-		WriteTimeout: happo_agent.HTTP_TIMEOUT * time.Second,
+		ReadTimeout:  time.Duration(l.Timeout) * time.Second,
+		WriteTimeout: time.Duration(l.Timeout) * time.Second,
 	}
 
 	return http_config.Serve(tls_listener)

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -161,6 +161,8 @@ func CmdDaemon(c *cli.Context) {
 	db.MetricsMaxLifetimeSeconds = c.Int64("metrics-max-lifetime-seconds")
 	db.MachineStateMaxLifetimeSeconds = c.Int64("machine-state-max-lifetime-seconds")
 
+	model.SetProxyTimeout(c.Int64("proxy-timeout-seconds"))
+
 	m.Get("/", func() string {
 		return "OK"
 	})

--- a/commands.go
+++ b/commands.go
@@ -76,6 +76,12 @@ var daemonFlags = []cli.Flag{
 		Usage:  "Machine State Max Lifetime Seconds.",
 		EnvVar: "HAPPO_AGENT_MACHINE_STATE_MAX_LIFETIME_SECONDS",
 	},
+	cli.Int64Flag{
+		Name:   "proxy-timeout-seconds",
+		Value:  180,
+		Usage:  "/proxy timeout Seconds.",
+		EnvVar: "HAPPO_AGENT_PROXY_TIMEOUT_SECONDS",
+	},
 }
 
 var Commands = []cli.Command{

--- a/model/monitor.go
+++ b/model/monitor.go
@@ -61,6 +61,10 @@ func Monitor(monitor_request happo_agent.MonitorRequest, r render.Render) {
 	if err != nil {
 		monitor_response.Return_Value = happo_agent.MONITOR_ERROR
 		monitor_response.Message = err.Error()
+		if _, ok := err.(*util.TimeoutError); ok {
+			r.JSON(http.StatusServiceUnavailable, monitor_response)
+			return
+		}
 		r.JSON(http.StatusBadRequest, monitor_response)
 		return
 	}

--- a/model/monitor_test.go
+++ b/model/monitor_test.go
@@ -1,0 +1,179 @@
+package model
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/codegangsta/martini-contrib/render"
+	"github.com/go-martini/martini"
+	"github.com/heartbeatsjp/happo-lib"
+	"github.com/martini-contrib/binding"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonitor1(t *testing.T) {
+	// OK
+
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/monitor", binding.Json(happo_agent.MonitorRequest{}), Monitor)
+
+	reader := bytes.NewReader([]byte(`{
+		"apikey": "",
+		"plugin_name": "monitor_test_plugin",
+		"plugin_option": "0"
+	}`))
+	req, _ := http.NewRequest("POST", "/monitor", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	lastRunned = time.Now().Unix() //avoid saveMachineState
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, res.Code, http.StatusOK)
+	assert.Equal(t,
+		res.Body.String(),
+		`{"return_value":0,"message":"Output of monitor_test_plugin. exit status is 0\n"}`,
+	)
+}
+
+func TestMonitor2(t *testing.T) {
+	// Warning
+
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/monitor", binding.Json(happo_agent.MonitorRequest{}), Monitor)
+
+	reader := bytes.NewReader([]byte(`{
+		"apikey": "",
+		"plugin_name": "monitor_test_plugin",
+		"plugin_option": "1"
+	}`))
+	req, _ := http.NewRequest("POST", "/monitor", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	lastRunned = time.Now().Unix() //avoid saveMachineState
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, res.Code, http.StatusOK)
+	assert.Equal(t,
+		res.Body.String(),
+		`{"return_value":1,"message":"Output of monitor_test_plugin. exit status is 1\n"}`,
+	)
+}
+
+func TestMonitor3(t *testing.T) {
+	// Critical
+
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/monitor", binding.Json(happo_agent.MonitorRequest{}), Monitor)
+
+	reader := bytes.NewReader([]byte(`{
+		"apikey": "",
+		"plugin_name": "monitor_test_plugin",
+		"plugin_option": "2"
+	}`))
+	req, _ := http.NewRequest("POST", "/monitor", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	lastRunned = time.Now().Unix() //avoid saveMachineState
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, res.Code, http.StatusOK)
+	assert.Equal(t,
+		res.Body.String(),
+		`{"return_value":2,"message":"Output of monitor_test_plugin. exit status is 2\n"}`,
+	)
+}
+
+func TestMonitor4(t *testing.T) {
+	// Other
+
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/monitor", binding.Json(happo_agent.MonitorRequest{}), Monitor)
+
+	reader := bytes.NewReader([]byte(`{
+		"apikey": "",
+		"plugin_name": "monitor_test_plugin",
+		"plugin_option": "3"
+	}`))
+	req, _ := http.NewRequest("POST", "/monitor", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	lastRunned = time.Now().Unix() //avoid saveMachineState
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, res.Code, http.StatusOK)
+	assert.Equal(t,
+		res.Body.String(),
+		`{"return_value":3,"message":"Output of monitor_test_plugin. exit status is 3\n"}`,
+	)
+}
+
+func TestMonitor5(t *testing.T) {
+	// Timeout
+
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/monitor", binding.Json(happo_agent.MonitorRequest{}), Monitor)
+
+	reader := bytes.NewReader([]byte(fmt.Sprintf(`{
+		"apikey": "",
+		"plugin_name": "monitor_test_sleep",
+		"plugin_option": "%d"
+	}`, happo_agent.COMMAND_TIMEOUT+1)))
+	req, _ := http.NewRequest("POST", "/monitor", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	lastRunned = time.Now().Unix() //avoid saveMachineState
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, res.Code, http.StatusServiceUnavailable)
+	assert.Regexp(t,
+		regexp.MustCompile(`^{"return_value":2,"message":"Exec timeout: .*monitor_test_sleep .*"}$`),
+		res.Body.String(),
+	)
+}
+
+func TestMonitor6(t *testing.T) {
+	// plugin not found
+
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/monitor", binding.Json(happo_agent.MonitorRequest{}), Monitor)
+
+	reader := bytes.NewReader([]byte(fmt.Sprintf(`{
+		"apikey": "",
+		"plugin_name": "notfound",
+		"plugin_option": "%d"
+	}`, happo_agent.COMMAND_TIMEOUT+1)))
+	req, _ := http.NewRequest("POST", "/monitor", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	lastRunned = time.Now().Unix() //avoid saveMachineState
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, res.Code, http.StatusOK)
+	assert.Equal(t,
+		res.Body.String(),
+		`{"return_value":127,"message":""}`,
+	)
+}

--- a/model/monitor_test_plugin
+++ b/model/monitor_test_plugin
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Output of $(basename $0). exit status is $1"
+exit $1

--- a/model/monitor_test_sleep
+++ b/model/monitor_test_sleep
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sleep $1
+echo "sleep $1 secs"

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -70,8 +70,8 @@ func postToAgent(host string, port int, request_type string, jsonData []byte) (i
 
 	resp, err := _httpClient.Do(req)
 	if err != nil {
-		if err, ok := err.(net.Error); ok && err.Timeout() {
-			return http.StatusGatewayTimeout, "", err
+		if errTimeout, ok := err.(net.Error); ok && errTimeout.Timeout() {
+			return http.StatusGatewayTimeout, "", errTimeout
 		}
 		return http.StatusBadGateway, "", err
 	}

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/codegangsta/martini-contrib/render"
 	"github.com/heartbeatsjp/happo-lib"
@@ -81,4 +82,8 @@ func postToAgent(host string, port int, request_type string, jsonData []byte) (i
 		return http.StatusBadGateway, "", err
 	}
 	return resp.StatusCode, string(body[:]), nil
+}
+
+func SetProxyTimeout(timeoutSeconds int64) {
+	_httpClient.Timeout = time.Duration(timeoutSeconds) * time.Second
 }

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -69,6 +70,9 @@ func postToAgent(host string, port int, request_type string, jsonData []byte) (i
 
 	resp, err := _httpClient.Do(req)
 	if err != nil {
+		if err, ok := err.(net.Error); ok && err.Timeout() {
+			return http.StatusGatewayTimeout, "", err
+		}
 		return http.StatusBadGateway, "", err
 	}
 	body, err := ioutil.ReadAll(resp.Body)

--- a/util/util.go
+++ b/util/util.go
@@ -21,6 +21,14 @@ import (
 var CommandTimeout time.Duration = -1
 var Production bool
 
+type TimeoutError struct {
+	Message string
+}
+
+func (err *TimeoutError) Error() string {
+	return err.Message
+}
+
 // --- Function
 func init() {
 	Production = strings.ToLower(os.Getenv("MARTINI_ENV")) == "production"
@@ -42,7 +50,7 @@ func ExecCommand(command string, option string) (int, string, string, error) {
 	exitStatus, stdout, stderr, err := tio.Run()
 
 	if err == nil && exitStatus.IsTimedOut() {
-		err = errors.New("Exec timeout: " + command_with_options)
+		err = &TimeoutError{"Exec timeout: " + command_with_options}
 	}
 
 	return exitStatus.GetChildExitCode(), stdout, stderr, err
@@ -69,7 +77,7 @@ func ExecCommandCombinedOutput(command string, option string) (int, string, erro
 	exitStatus := <-ch
 
 	if err == nil && exitStatus.IsTimedOut() {
-		err = errors.New("Exec timeout: " + command_with_options)
+		err = &TimeoutError{"Exec timeout: " + command_with_options}
 	}
 
 	return exitStatus.GetChildExitCode(), out.String(), err

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -19,6 +19,9 @@ func TestExecCommand1(t *testing.T) {
 	assert.Contains(t, stdout, "hoge")
 	assert.Contains(t, stderr, "")
 	assert.Nil(t, err)
+
+	_, ok := err.(*TimeoutError)
+	assert.False(t, ok)
 }
 
 func TestExecCommand2(t *testing.T) {
@@ -30,6 +33,9 @@ func TestExecCommand2(t *testing.T) {
 	assert.Contains(t, stdout, "")
 	assert.Contains(t, stderr, "hoge")
 	assert.Nil(t, err)
+
+	_, ok := err.(*TimeoutError)
+	assert.False(t, ok)
 }
 
 func TestExecCommand3(t *testing.T) {
@@ -41,6 +47,9 @@ func TestExecCommand3(t *testing.T) {
 	assert.Contains(t, stdout, "")
 	assert.Contains(t, stderr, "")
 	assert.NotNil(t, err)
+
+	_, ok := err.(*TimeoutError)
+	assert.True(t, ok)
 }
 
 func TestExecCommandCombinedOutput1(t *testing.T) {
@@ -51,6 +60,9 @@ func TestExecCommandCombinedOutput1(t *testing.T) {
 	assert.EqualValues(t, exit_code, 0)
 	assert.Contains(t, out, "hoge")
 	assert.Nil(t, err)
+
+	_, ok := err.(*TimeoutError)
+	assert.False(t, ok)
 }
 
 func TestExecCommandCombinedOutput2(t *testing.T) {
@@ -61,6 +73,9 @@ func TestExecCommandCombinedOutput2(t *testing.T) {
 	assert.EqualValues(t, exit_code, 0)
 	assert.Contains(t, out, "hoge")
 	assert.Nil(t, err)
+
+	_, ok := err.(*TimeoutError)
+	assert.False(t, ok)
 }
 
 func TestExecCommandCombinedOutput3(t *testing.T) {
@@ -71,6 +86,9 @@ func TestExecCommandCombinedOutput3(t *testing.T) {
 	assert.EqualValues(t, exit_code, -1)
 	assert.Contains(t, out, "")
 	assert.NotNil(t, err)
+
+	_, ok := err.(*TimeoutError)
+	assert.True(t, ok)
 }
 
 func TestExecCommand4(t *testing.T) {
@@ -81,6 +99,9 @@ func TestExecCommand4(t *testing.T) {
 	assert.EqualValues(t, exit_code, 0)
 	assert.Contains(t, out, "1.STDOUT.2.STDERR.3.STDOUT.4.STDERR.")
 	assert.Nil(t, err)
+
+	_, ok := err.(*TimeoutError)
+	assert.False(t, ok)
 }
 
 func TestBuildMetricAppendAPIRequest1(t *testing.T) {

--- a/wercker.yml
+++ b/wercker.yml
@@ -16,7 +16,10 @@ build:
         code: "glide install"
     - script: 
         name: "install test plugin"
-        code: "install -m 755 collect/metrics_test_plugin /usr/local/bin/metrics_test_plugin"
+        code: |
+            install -m 755 collect/metrics_test_plugin /usr/local/bin/metrics_test_plugin
+            install -m 755 model/monitor_test_plugin /usr/local/bin/monitor_test_plugin
+            install -m 755 model/monitor_test_sleep /usr/local/bin/monitor_test_sleep
     - script: 
         name: "go test"
         code: "go test $(glide novendor)"


### PR DESCRIPTION
When timeout occured, now return `400 Bad Request` .
I think this is not suitable.

- /monitor timeout (command timeout) should return `503 Service Unavailable`
    - When command timeout occured, `504 Gateway Timeout` is not natural to me.
- /proxy timeout should return `504 Gateway Timeout` (now `502 Bad Gateway` )