### PR TITLE
rename package lib to halib for dependency convenience

### DIFF
--- a/halib/tool.go
+++ b/halib/tool.go
@@ -1,0 +1,40 @@
+package halib
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// GetProxyJSON returns Marshal-ed ProxyRequest in []byte
+func GetProxyJSON(proxyHosts []string, host string, port int, requestType string, proxyJSONStr []byte) ([]byte, string, int, error) {
+	var agentHost string
+	var agentPort int
+	var err error
+
+	// Step 1
+	agentHostport := strings.Split(proxyHosts[0], ":")
+	agentHost = agentHostport[0]
+	if len(agentHostport) == 2 {
+		agentPort, err = strconv.Atoi(agentHostport[1])
+		if err != nil {
+			return nil, "", 0, err
+		}
+	} else {
+		agentPort = DefaultAgentPort
+	}
+
+	// Step 2 or later
+	proxyHosts = proxyHosts[1:]
+	proxyHosts = append(proxyHosts, fmt.Sprintf("%s:%d", host, port))
+
+	proxyRequest := ProxyRequest{
+		ProxyHostPort: proxyHosts,
+		RequestType:   requestType,
+		RequestJSON:   proxyJSONStr,
+	}
+	jsonData, _ := json.Marshal(proxyRequest)
+
+	return jsonData, agentHost, agentPort, nil
+}

--- a/halib/tool_test.go
+++ b/halib/tool_test.go
@@ -1,0 +1,50 @@
+package halib
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const HOST = "10.0.0.1"
+const PORT = DefaultAgentPort
+const METHOD = "TEST"
+const JSON = "{\"test\":100}"
+
+func TestGetProxyJSON1(t *testing.T) {
+	ProxyHosts := []string{"192.168.0.1"}
+	var jsonData ProxyRequest
+	ProxyRequest := ProxyRequest{
+		ProxyHostPort: []string{fmt.Sprintf("%s:%d", HOST, PORT)},
+		RequestType:   METHOD,
+		RequestJSON:   ([]byte)(JSON),
+	}
+
+	jsonStr, agentHost, agentPort, err := GetProxyJSON(ProxyHosts, HOST, PORT, "TEST", ([]byte(JSON)))
+	assert.Nil(t, err)
+	assert.EqualValues(t, "192.168.0.1", agentHost)
+	assert.EqualValues(t, DefaultAgentPort, agentPort)
+
+	json.Unmarshal(jsonStr, &jsonData)
+	assert.EqualValues(t, ProxyRequest, jsonData)
+}
+
+func TestGetProxyJSON2(t *testing.T) {
+	ProxyHosts := []string{"192.168.0.1", "172.16.0.1"}
+	var jsonData ProxyRequest
+	ProxyRequest := ProxyRequest{
+		ProxyHostPort: []string{"172.16.0.1", fmt.Sprintf("%s:%d", HOST, PORT)},
+		RequestType:   METHOD,
+		RequestJSON:   ([]byte)(JSON),
+	}
+
+	jsonStr, agentHost, agentPort, err := GetProxyJSON(ProxyHosts, HOST, PORT, "TEST", ([]byte(JSON)))
+	assert.Nil(t, err)
+	assert.EqualValues(t, "192.168.0.1", agentHost)
+	assert.EqualValues(t, DefaultAgentPort, agentPort)
+
+	json.Unmarshal(jsonStr, &jsonData)
+	assert.EqualValues(t, ProxyRequest, jsonData)
+}


### PR DESCRIPTION
rename package lib to halib for dependency convenience.

`lib` tends to conflict to local package.