### PR TITLE
re-design response

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Call monitor plugin. It likes nrpe.
     - return\_code: commands return code
     - return\_value: commands return value (stdout, stderr)
 
-In case `--command-timeout` reached, return `503 Service Unavailable` .
+In case `--command-timeout` reached, return `500 Internal Server Error` .
 
 ```
 $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/monitor --post-data='{"apikey": "", "plugin_name": "check_procs", "plugin_option": "-w 100 -c 200"}'

--- a/model/monitor.go
+++ b/model/monitor.go
@@ -67,11 +67,11 @@ func Monitor(monitorRequest halib.MonitorRequest, r render.Render) {
 	if err != nil {
 		monitorResponse.ReturnValue = halib.MonitorError
 		monitorResponse.Message = err.Error()
-		if _, ok := err.(*util.TimeoutError); ok {
-			r.JSON(http.StatusServiceUnavailable, monitorResponse)
-			return
-		}
-		r.JSON(http.StatusBadRequest, monitorResponse)
+		//if _, ok := err.(*util.TimeoutError); ok {
+		//	r.JSON(http.StatusInternalServerError, monitorResponse)
+		//	return
+		//}
+		r.JSON(http.StatusInternalServerError, monitorResponse)
 		return
 	}
 	if ret != 0 {
@@ -99,13 +99,16 @@ func execPluginCommand(pluginName string, pluginOption string) (int, string, err
 		}
 	}
 
-	exitstatus, stdout, _, err := util.ExecCommand(plugin, pluginOption)
+	exitstatus, stdout, stderr, err := util.ExecCommand(plugin, pluginOption)
 
-	if err != nil {
-		return halib.MonitorUnknown, "", err
+	out := stdout
+	if stdout == "" {
+		out = fmt.Sprintf(`stdout=, stderr=%s`, stderr)
+	} else if stderr != "" {
+		out = fmt.Sprintf("%s, stderr=%s", stdout, stderr)
 	}
 
-	return exitstatus, stdout, nil
+	return exitstatus, out, err
 }
 
 func saveMachineState() error {

--- a/model/monitor_test.go
+++ b/model/monitor_test.go
@@ -173,7 +173,7 @@ func TestMonitor6(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t,
-		`{"return_value":127,"message":""}`,
+		`{"return_value":127,"message":"stdout=, stderr=/bin/sh: 1: /usr/local/bin/notfound: not found\n"}`,
 		res.Body.String(),
 	)
 }

--- a/model/monitor_test.go
+++ b/model/monitor_test.go
@@ -144,7 +144,7 @@ func TestMonitor5(t *testing.T) {
 	lastRunned = time.Now().Unix() //avoid saveMachineState
 	m.ServeHTTP(res, req)
 
-	assert.Equal(t, http.StatusServiceUnavailable, res.Code)
+	assert.Equal(t, http.StatusInternalServerError, res.Code)
 	assert.Regexp(t,
 		regexp.MustCompile(`^{"return_value":2,"message":"Exec timeout: .*monitor_test_sleep .*"}$`),
 		res.Body.String(),

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -76,12 +76,15 @@ func postToAgent(host string, port int, requestType string, jsonData []byte) (in
 		if errTimeout, ok := err.(net.Error); ok && errTimeout.Timeout() {
 			return http.StatusGatewayTimeout, "", errTimeout
 		}
-		return http.StatusBadGateway, "", err
+		if resp.StatusCode == http.StatusInternalServerError || resp.StatusCode == 0 {
+			return http.StatusServiceUnavailable, "", err
+		}
+		return resp.StatusCode, "", err
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return http.StatusBadGateway, "", err
+		return http.StatusInternalServerError, "", err
 	}
 	return resp.StatusCode, string(body[:]), nil
 }


### PR DESCRIPTION
to be more intuitive.

- `/monitor`
    - response 400 => 500 (Internal Server Error)
    - if external command's stdout is empty, response message part is `stdout=, stderr={stderr}`
    - if external command's stderr is **not** empty, response message part is `{stdout}, stderr={stderr}`
- `/proxy`
    - response 400 => 500 (Internal Server Error)
    - when origin returns 500, proxy returns 503