### PR TITLE
add feature disable collect metrics

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -165,14 +165,19 @@ func CmdDaemon(c *cli.Context) {
 		}
 	}()
 
+	disableCollectMetrics := c.Bool("disable-collect-metrics")
+	util.HappoAgentLogger().Debug("disable-collect-metrics: ", disableCollectMetrics)
+
 	// Metric collect timer
 	timeMetrics := time.NewTicker(time.Minute).C
 	for {
 		select {
 		case <-timeMetrics:
-			err := collect.Metrics(c.String("metric-config"))
-			if err != nil {
-				log.Fatal(err)
+			if !disableCollectMetrics {
+				err := collect.Metrics(c.String("metric-config"))
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 		}
 	}

--- a/commands.go
+++ b/commands.go
@@ -120,6 +120,11 @@ var daemonFlags = []cli.Flag{
 		Usage:  "sensu-plugin paths.",
 		EnvVar: "HAPPO_AGENT_SENSU_PLUGIN_PATHS",
 	},
+	cli.BoolFlag{
+		Name:   "disable-collect-metrics",
+		Usage:  "disable collect metrics ( if true, metrics.yaml has no meaning )",
+		EnvVar: "HAPPO_AGENT_DISABLE_COLLECT_METRICS",
+	},
 }
 
 // Commands is list of subcommand

--- a/contrib/etc/default/happo-agent.env
+++ b/contrib/etc/default/happo-agent.env
@@ -21,3 +21,4 @@ HAPPO_AGENT_DBFILE="/var/lib/happo-agent.db"
 #HAPPO_AGENT_ERROR_LOG_INTERVAL_SECONDS=-1
 #HAPPO_AGENT_NAGIOS_PLUGIN_PATHS="/usr/local/hb-agent/bin,/usr/lib64/nagios/plugins,/usr/lib/nagios/plugins,/usr/local/nagios/libexec,/usr/local/bin"
 #HAPPO_AGENT_SENSU_PLUGIN_PATHS="/usr/local/hb-agent/bin,/usr/local/bin"
+#HAPPO_AGENT_DISABLE_COLLECT_METRICS=""


### PR DESCRIPTION
In case happo-agent use as just only "Yet Another NRPE", collect metrics want to be disabled.

I think we should endpoint keep be enabled. To enable collect metrics in the future maybe.