### PR TITLE
add feature autoscaling instance deregister

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,21 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/autoscaling/refresh
 {"status":"OK","message":""}
 ```
 
+### /autoscaling/instance/deregister
+
+Delete autocaling instances
+
+- Input format
+    - JSON
+- Input variables
+    - apikey: ""
+    - instance_id: instance id by Amazon EC2
+- Return format
+    - JSON
+- Return variables
+    - status: result status
+    - message: message from agent (if error occurred)
+
 ### /status
 
 Get happo-agent status

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -108,12 +108,14 @@ func getInstanceData(transaction *leveldb.Transaction, instanceID string) ([]byt
 
 	iter := transaction.NewIterator(leveldbUtil.BytesPrefix([]byte("ag-")), nil)
 	for iter.Next() {
+		var d halib.InstanceData
 		value := iter.Value()
 
 		dec := gob.NewDecoder(bytes.NewReader(value))
-		dec.Decode(&instanceData)
-		if instanceData.InstanceID == instanceID {
+		dec.Decode(&d)
+		if d.InstanceID == instanceID {
 			key = iter.Key()
+			instanceData = d
 			break
 		}
 	}

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -102,6 +102,70 @@ func GetAutoScalingConfig(configFile string) (halib.AutoScalingConfig, error) {
 	return autoscalingConfig, nil
 }
 
+func getInstanceData(transaction *leveldb.Transaction, instanceID string) ([]byte, halib.InstanceData) {
+	var key []byte
+	var instanceData halib.InstanceData
+
+	iter := transaction.NewIterator(leveldbUtil.BytesPrefix([]byte("ag-")), nil)
+	for iter.Next() {
+		value := iter.Value()
+
+		dec := gob.NewDecoder(bytes.NewReader(value))
+		dec.Decode(&instanceData)
+		if instanceData.InstanceID == instanceID {
+			key = iter.Key()
+			break
+		}
+	}
+
+	return key, instanceData
+}
+
+// DeregisterAutoScalingInstance deregister autoscaling instance from dbms
+func DeregisterAutoScalingInstance(instanceID string) error {
+	log := util.HappoAgentLogger()
+
+	transaction, err := db.DB.OpenTransaction()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	key, instanceData := getInstanceData(transaction, instanceID)
+	if key == nil {
+		transaction.Discard()
+		err := fmt.Errorf("%s is not registered", instanceID)
+		log.Error(err)
+		return err
+	}
+
+	err = transaction.Delete(key, nil)
+	if err != nil {
+		transaction.Discard()
+		log.Error(err)
+		return err
+	}
+
+	instanceData.InstanceID = ""
+	instanceData.IP = ""
+	var b bytes.Buffer
+	enc := gob.NewEncoder(&b)
+	err = enc.Encode(instanceData)
+	transaction.Put(
+		key,
+		b.Bytes(),
+		nil,
+	)
+
+	err = transaction.Commit()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	return nil
+}
+
 func makeRegisteredInstances(transaction *leveldb.Transaction, autoScalingGroupName, hostPrefix string) map[string]halib.InstanceData {
 	registeredInstances := map[string]halib.InstanceData{}
 

--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -245,6 +245,43 @@ func TestGetAutoScalingConfig(t *testing.T) {
 	}
 }
 
+func TestDeregisterAutoScalingInstance(t *testing.T) {
+	var cases = []struct {
+		name         string
+		input        string
+		isNormalTest bool
+	}{
+		{
+			name:         "deregister i-aaaaaa",
+			input:        "i-aaaaaa",
+			isNormalTest: true,
+		},
+		{
+			name:         "deregister i-zzzzzz",
+			input:        "i-zzzzzz",
+			isNormalTest: false,
+		},
+	}
+
+	client := &AWSClient{
+		svcEC2:         &mockEC2Client{},
+		svcAutoscaling: &mockAutoScalingClient{},
+	}
+	RefreshAutoScalingInstances(client, "dummy-prod-ag", "dummy-prod-app", 10)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := DeregisterAutoScalingInstance(c.input)
+			if c.isNormalTest {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+			}
+		})
+	}
+
+}
+
 type mockAutoScalingClient struct {
 	autoscalingiface.AutoScalingAPI
 }

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -145,6 +145,7 @@ func CmdDaemon(c *cli.Context) {
 	m.Post("/metric/append", binding.Json(halib.MetricAppendRequest{}), model.MetricAppend)
 	m.Post("/metric/config/update", binding.Json(halib.MetricConfigUpdateRequest{}), model.MetricConfigUpdate)
 	m.Post("/autoscaling/refresh", binding.Json(halib.AutoScalingRefreshRequest{}), model.AutoScalingRefresh)
+	m.Post("/autoscaling/instance/deregister", binding.Json(halib.AutoScalingInstanceDeregisterRequest{}), model.AutoScalingInstanceDeregister)
 	m.Post("/autoscaling/config/update", binding.Json(halib.AutoScalingConfigUpdateRequest{}), model.AutoScalingConfigUpdate)
 	m.Get("/autoscaling", model.AutoScaling)
 	m.Get("/metric/status", model.MetricDataBufferStatus)

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -91,6 +91,12 @@ type AutoScalingRefreshRequest struct {
 	AutoScalingGroupName string `json:"autoscaling_group_name"`
 }
 
+// AutoScalingInstanceDeregisterRequest is /autoscaling/instance/delete API
+type AutoScalingInstanceDeregisterRequest struct {
+	APIKey     string `json:"apikey"`
+	InstanceID string `json:"instance_id"`
+}
+
 // AutoScalingConfigUpdateRequest is /autoscaling/config/update API
 type AutoScalingConfigUpdateRequest struct {
 	APIKey string            `json:"apikey"`
@@ -142,6 +148,12 @@ type AutoScalingResponse struct {
 
 // AutoScalingRefreshResponse is /autoscaling/refresh API
 type AutoScalingRefreshResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// AutoScalingInstanceDeregisterResponse is /autoscaling/instance/delete API
+type AutoScalingInstanceDeregisterResponse struct {
 	Status  string `json:"status"`
 	Message string `json:"message"`
 }

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -44,6 +44,13 @@ func AutoScalingConfigUpdate(autoScalingRequest halib.AutoScalingConfigUpdateReq
 func AutoScalingInstanceDeregister(request halib.AutoScalingInstanceDeregisterRequest, r render.Render) {
 	var response halib.AutoScalingInstanceDeregisterResponse
 
+	if request.InstanceID == "" {
+		response.Status = "NG"
+		response.Message = "instance_id required"
+		r.JSON(http.StatusBadRequest, response)
+		return
+	}
+
 	err := autoscaling.DeregisterAutoScalingInstance(request.InstanceID)
 	if err != nil {
 		response.Status = "NG"

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -40,6 +40,21 @@ func AutoScalingConfigUpdate(autoScalingRequest halib.AutoScalingConfigUpdateReq
 	r.JSON(http.StatusOK, autoScalingResponse)
 }
 
+// AutoScalingInstanceDeregister deregister autoscaling instance from dbms
+func AutoScalingInstanceDeregister(request halib.AutoScalingInstanceDeregisterRequest, r render.Render) {
+	var response halib.AutoScalingInstanceDeregisterResponse
+
+	err := autoscaling.DeregisterAutoScalingInstance(request.InstanceID)
+	if err != nil {
+		response.Status = "NG"
+		response.Message = err.Error()
+	} else {
+		response.Status = "OK"
+	}
+
+	r.JSON(http.StatusOK, response)
+}
+
 // AutoScalingRefresh refresh autoscaling
 func AutoScalingRefresh(request halib.AutoScalingRefreshRequest, r render.Render) {
 	var response halib.AutoScalingRefreshResponse


### PR DESCRIPTION
`/autoscaling/instance/deregister` is new endpoint for deregister autoscaling instance.

an aim of this feature is not delete DB entry contain instance data, but deregister instance.
for that reason, deregister's implement is put empty value to `InstanceData.InstanceID` and `InstanceData.IP`.

Please review.
