### PR TITLE
Delete happo-agent_linux_amd64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/
 .wercker/
 debug
 .vscode/
+happo-agent_linux_amd64


### PR DESCRIPTION
I was pushed wrong commit in https://github.com/heartbeatsjp/happo-agent/pull/39. This PR is fix it.