### PR TITLE
add feature autoscaling delete

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -365,6 +365,25 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/autoscaling/refresh
 {"status":"OK","message":""}
 ```
 
+### /autoscaling/delete
+
+AutoScalingグループのインスタンスデータを削除します。
+
+- 入力形式
+    - JSON
+- 入力変数
+    - autoscaling_group_name: autoscaling group name
+- 返り値の形式
+    - JSON
+- 返り値の変数　
+    - status: 実行結果のステータス
+    - message: エージェントからのメッセージ (特にエラーがあれば掲載)
+
+```
+$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/autoscaling/delete --post-data="{\"autoscaling_group_name\": \"hb-autoscaling\"}"
+{"status":"OK","message":""}
+```
+
 ## Contribution
 
 1. Fork ([http://github.com/heartbeatsjp/happo-agent/fork](http://github.com/heartbeatsjp/happo-agent/fork))

--- a/README.md
+++ b/README.md
@@ -358,9 +358,28 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/autoscaling/refresh
 {"status":"OK","message":""}
 ```
 
+### /autoscaling/delete
+
+Delete autoscaling instances data
+
+- Input format
+    - JSON
+- Input variables
+    - autoscaling_group_name: autoscaling group name
+- Return format
+    - JSON
+- Return variables
+    - status: result status
+    - message: message from agent (if error occurred)
+
+```
+$ wget -q --no-check-certificate -O - https://127.0.0.1:6777/autoscaling/delete --post-data="{\"autoscaling_group_name\": \"hb-autoscaling\"}"
+{"status":"OK","message":""}
+```
+
 ### /autoscaling/instance/deregister
 
-Delete autocaling instances
+Deregister autocaling instances
 
 - Input format
     - JSON

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -320,3 +320,8 @@ func RefreshAutoScalingInstances(client *AWSClient, autoScalingGroupName, hostPr
 
 	return nil
 }
+
+// DeleteAutoScaling delete autoscaling instances data
+func DeleteAutoScaling(autoScalingGroupName string) error {
+	return nil
+}

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -145,6 +145,7 @@ func CmdDaemon(c *cli.Context) {
 	m.Post("/metric/append", binding.Json(halib.MetricAppendRequest{}), model.MetricAppend)
 	m.Post("/metric/config/update", binding.Json(halib.MetricConfigUpdateRequest{}), model.MetricConfigUpdate)
 	m.Post("/autoscaling/refresh", binding.Json(halib.AutoScalingRefreshRequest{}), model.AutoScalingRefresh)
+	m.Post("/autoscaling/delete", binding.Json(halib.AutoScalingDeleteRequest{}), model.AutoScalingDelete)
 	m.Post("/autoscaling/instance/deregister", binding.Json(halib.AutoScalingInstanceDeregisterRequest{}), model.AutoScalingInstanceDeregister)
 	m.Post("/autoscaling/config/update", binding.Json(halib.AutoScalingConfigUpdateRequest{}), model.AutoScalingConfigUpdate)
 	m.Get("/autoscaling", model.AutoScaling)

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -91,6 +91,12 @@ type AutoScalingRefreshRequest struct {
 	AutoScalingGroupName string `json:"autoscaling_group_name"`
 }
 
+// AutoScalingDeleteRequest is /autoscaling/delete API
+type AutoScalingDeleteRequest struct {
+	APIKey               string `json:"apikey"`
+	AutoScalingGroupName string `json:"autoscaling_group_name"`
+}
+
 // AutoScalingInstanceDeregisterRequest is /autoscaling/instance/delete API
 type AutoScalingInstanceDeregisterRequest struct {
 	APIKey     string `json:"apikey"`
@@ -148,6 +154,12 @@ type AutoScalingResponse struct {
 
 // AutoScalingRefreshResponse is /autoscaling/refresh API
 type AutoScalingRefreshResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// AutoScalingDeleteResponse is /autoscaling/delete API
+type AutoScalingDeleteResponse struct {
 	Status  string `json:"status"`
 	Message string `json:"message"`
 }

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -98,6 +98,7 @@ func AutoScalingDelete(request halib.AutoScalingDeleteRequest, r render.Render) 
 		return
 	}
 
+	response.Status = "OK"
 	r.JSON(http.StatusOK, response)
 }
 

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -89,6 +89,13 @@ func AutoScalingDelete(request halib.AutoScalingDeleteRequest, r render.Render) 
 		}
 	}
 
+	if deleteAutoScalingGroup == "" {
+		response.Status = "error"
+		response.Message = "can't find autoscaling group name in config"
+		r.JSON(http.StatusNotFound, response)
+		return
+	}
+
 	if err := autoscaling.DeleteAutoScaling(deleteAutoScalingGroup); err != nil {
 		response.Status = "error"
 		response.Message = err.Error()


### PR DESCRIPTION
`/autoscaling/delete` is new endpoint for delete autoscaling instances data.
It can be used when delete actual AutoScaling Group or reduce AutoScaling Group max size.

want to be delete one instance, in that case use `autoscaling/instances/deregister` API.

Please review.
