### PR TITLE
Autoscaling register instance

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -375,7 +375,7 @@ AutoScalingグループのインスタンスデータを削除します。
     - autoscaling_group_name: autoscaling group name
 - 返り値の形式
     - JSON
-- 返り値の変数　
+- 返り値の変数
     - status: 実行結果のステータス
     - message: エージェントからのメッセージ (特にエラーがあれば掲載)
 
@@ -383,6 +383,31 @@ AutoScalingグループのインスタンスデータを削除します。
 $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/autoscaling/delete --post-data="{\"autoscaling_group_name\": \"hb-autoscaling\"}"
 {"status":"OK","message":""}
 ```
+
+### /autoscaling/instance/register
+
+AutoScalingのインスタンスを登録します。
+
+- 入力形式
+    - JSON
+- 入力変数
+    - apikey: ""
+    - autoscaling_group_name: AutoScaling Group名
+    - ip: プライベートIPアドレス
+    - instance_id: インスタンスID
+- 出力形式
+    - JSON
+- 出力変数
+    - status: 実行結果のステータス
+    - message: エージェントからのメッセージ (特にエラーがあれば掲載)
+    - alias: インスタンスに割り当てられたエイリアス
+    - instance_data:
+        - ip: プライベートIPアドレス
+        - instance_id: インスタンスID
+        - metric_plugins:
+            - (Array)
+                - plugin_name: メトリックプラグイン名
+                - plugin_option: メトリックプラグインのオプション
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,30 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/autoscaling/delete 
 {"status":"OK","message":""}
 ```
 
+### /autoscaling/instance/register
+
+Register autoscaling instance
+
+- Input format
+    - JSON
+- Input variables
+    - apikey: ""
+    - autoscaling_group_name: autoscaling group name
+    - ip: private ip address by Amazon EC2
+    - instance_id: instance id by Amazon EC2
+- Return format
+    - JSON
+- Return variables
+    - status: result status
+    - message: message from agent (if error occurred)
+    - instance_data:
+        - ip: private ip address by Amazon EC2
+        - instance_id: instance id by Amazon EC2
+        - metric_plugins:
+            - (Array)
+                - plugin_name: metric plugin name
+                - plugin_option: metric plugin option
+
 ### /autoscaling/instance/deregister
 
 Deregister autocaling instances

--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Register autoscaling instance
 - Return variables
     - status: result status
     - message: message from agent (if error occurred)
+    - alias: assigned alias to instance
     - instance_data:
         - ip: private ip address by Amazon EC2
         - instance_id: instance id by Amazon EC2

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -146,19 +146,19 @@ func getEmptyAlias(transaction *leveldb.Transaction, autoScalingGroupName, hostP
 }
 
 // RegisterAutoScalingInstance register autoscaling instance to dbms
-func RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, instanceID, ip string) error {
+func RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, instanceID, ip string) (halib.InstanceData, error) {
 	log := util.HappoAgentLogger()
 
 	transaction, err := db.DB.OpenTransaction()
 	if err != nil {
 		log.Error(err)
-		return err
+		return halib.InstanceData{}, err
 	}
 
 	newAlias, newInstanceData := getEmptyAlias(transaction, autoScalingGroupName, hostPrefix)
 	if newAlias == nil {
 		transaction.Discard()
-		return fmt.Errorf("can't find empty alias from %s", autoScalingGroupName)
+		return halib.InstanceData{}, fmt.Errorf("can't find empty alias from %s", autoScalingGroupName)
 	}
 
 	newInstanceData.InstanceID = instanceID
@@ -174,10 +174,10 @@ func RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, instanceID, i
 
 	if err := transaction.Commit(); err != nil {
 		log.Error(err)
-		return err
+		return halib.InstanceData{}, err
 	}
 
-	return nil
+	return newInstanceData, nil
 }
 
 // DeregisterAutoScalingInstance deregister autoscaling instance from dbms

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -155,6 +155,14 @@ func RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, instanceID, i
 		return halib.InstanceData{}, err
 	}
 
+	registeredInstances := makeRegisteredInstances(transaction, autoScalingGroupName, hostPrefix)
+	for _, registeredInstance := range registeredInstances {
+		if instanceID == registeredInstance.InstanceID {
+			transaction.Discard()
+			return halib.InstanceData{}, fmt.Errorf("already registered")
+		}
+	}
+
 	newAlias, newInstanceData := getEmptyAlias(transaction, autoScalingGroupName, hostPrefix)
 	if newAlias == nil {
 		transaction.Discard()

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -185,7 +185,7 @@ func RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, instanceID, i
 		return "", halib.InstanceData{}, err
 	}
 
-	return string(newAlias), newInstanceData, nil
+	return newAlias, newInstanceData, nil
 }
 
 // DeregisterAutoScalingInstance deregister autoscaling instance from dbms

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -123,6 +123,11 @@ func getInstanceData(transaction *leveldb.Transaction, instanceID string) ([]byt
 	return key, instanceData
 }
 
+// RegisterAutoScalingInstance register autoscaling instance to dbms
+func RegisterAutoScalingInstance(instanceID string) error {
+	return nil
+}
+
 // DeregisterAutoScalingInstance deregister autoscaling instance from dbms
 func DeregisterAutoScalingInstance(instanceID string) error {
 	log := util.HappoAgentLogger()

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -158,7 +158,7 @@ func RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, instanceID, i
 	newAlias, newInstanceData := getEmptyAlias(transaction, autoScalingGroupName, hostPrefix)
 	if newAlias == nil {
 		transaction.Discard()
-		return fmt.Errorf("")
+		return fmt.Errorf("can't find empty alias from %s", autoScalingGroupName)
 	}
 
 	newInstanceData.InstanceID = instanceID

--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -262,12 +262,15 @@ func TestGetAutoScalingConfig(t *testing.T) {
 
 func TestRegisterAutoScalingInstance(t *testing.T) {
 	var cases = []struct {
-		name         string
-		input1       string
-		input2       string
-		input3       string
-		input4       string
-		expected     halib.InstanceData
+		name     string
+		input1   string
+		input2   string
+		input3   string
+		input4   string
+		expected struct {
+			alias        string
+			instanceData halib.InstanceData
+		}
 		isNormalTest bool
 	}{
 		{
@@ -276,16 +279,22 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 			input2: "dummy-prod-app",
 			input3: "i-zzzzzz",
 			input4: "192.0.2.99",
-			expected: halib.InstanceData{
-				InstanceID: "i-zzzzzz",
-				IP:         "192.0.2.99",
-				MetricPlugins: []struct {
-					PluginName   string `json:"plugin_name"`
-					PluginOption string `json:"plugin_option"`
-				}{
-					{
-						PluginName:   "",
-						PluginOption: "",
+			expected: struct {
+				alias        string
+				instanceData halib.InstanceData
+			}{
+				alias: "dummy-prod-ag-dummy-prod-app-11",
+				instanceData: halib.InstanceData{
+					InstanceID: "i-zzzzzz",
+					IP:         "192.0.2.99",
+					MetricPlugins: []struct {
+						PluginName   string `json:"plugin_name"`
+						PluginOption string `json:"plugin_option"`
+					}{
+						{
+							PluginName:   "",
+							PluginOption: "",
+						},
 					},
 				},
 			},
@@ -297,13 +306,19 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 			input2: "dummy-prod-app",
 			input3: "i-aaaaaa",
 			input4: "192.0.2.11",
-			expected: halib.InstanceData{
-				InstanceID: "",
-				IP:         "",
-				MetricPlugins: []struct {
-					PluginName   string `json:"plugin_name"`
-					PluginOption string `json:"plugin_option"`
-				}(nil),
+			expected: struct {
+				alias        string
+				instanceData halib.InstanceData
+			}{
+				alias: "",
+				instanceData: halib.InstanceData{
+					InstanceID: "",
+					IP:         "",
+					MetricPlugins: []struct {
+						PluginName   string `json:"plugin_name"`
+						PluginOption string `json:"plugin_option"`
+					}(nil),
+				},
 			},
 			isNormalTest: false,
 		},
@@ -313,13 +328,19 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 			input2: "dummy-stg-app",
 			input3: "i-zzzzzz",
 			input4: "192.0.2.99",
-			expected: halib.InstanceData{
-				InstanceID: "",
-				IP:         "",
-				MetricPlugins: []struct {
-					PluginName   string `json:"plugin_name"`
-					PluginOption string `json:"plugin_option"`
-				}(nil),
+			expected: struct {
+				alias        string
+				instanceData halib.InstanceData
+			}{
+				alias: "",
+				instanceData: halib.InstanceData{
+					InstanceID: "",
+					IP:         "",
+					MetricPlugins: []struct {
+						PluginName   string `json:"plugin_name"`
+						PluginOption string `json:"plugin_option"`
+					}(nil),
+				},
 			},
 			isNormalTest: false,
 		},
@@ -329,13 +350,19 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 			input2: "dummy-missing-app",
 			input3: "i-zzzzzz",
 			input4: "192.0.2.99",
-			expected: halib.InstanceData{
-				InstanceID: "",
-				IP:         "",
-				MetricPlugins: []struct {
-					PluginName   string `json:"plugin_name"`
-					PluginOption string `json:"plugin_option"`
-				}(nil),
+			expected: struct {
+				alias        string
+				instanceData halib.InstanceData
+			}{
+				alias: "",
+				instanceData: halib.InstanceData{
+					InstanceID: "",
+					IP:         "",
+					MetricPlugins: []struct {
+						PluginName   string `json:"plugin_name"`
+						PluginOption string `json:"plugin_option"`
+					}(nil),
+				},
 			},
 			isNormalTest: false,
 		},
@@ -351,8 +378,9 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := RegisterAutoScalingInstance(c.input1, c.input2, c.input3, c.input4)
-			assert.Equal(t, c.expected, actual)
+			actualAlias, actualInstanceData, err := RegisterAutoScalingInstance(c.input1, c.input2, c.input3, c.input4)
+			assert.Equal(t, c.expected.alias, actualAlias)
+			assert.Equal(t, c.expected.instanceData, actualInstanceData)
 			if c.isNormalTest {
 				assert.Nil(t, err)
 			} else {

--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -260,6 +260,108 @@ func TestGetAutoScalingConfig(t *testing.T) {
 	}
 }
 
+func TestRegisterAutoScalingInstance(t *testing.T) {
+	var cases = []struct {
+		name         string
+		input1       string
+		input2       string
+		input3       string
+		input4       string
+		expected     halib.InstanceData
+		isNormalTest bool
+	}{
+		{
+			name:   "dummy-prod-ag",
+			input1: "dummy-prod-ag",
+			input2: "dummy-prod-app",
+			input3: "i-zzzzzz",
+			input4: "192.0.2.99",
+			expected: halib.InstanceData{
+				InstanceID: "i-zzzzzz",
+				IP:         "192.0.2.99",
+				MetricPlugins: []struct {
+					PluginName   string `json:"plugin_name"`
+					PluginOption string `json:"plugin_option"`
+				}{
+					{
+						PluginName:   "",
+						PluginOption: "",
+					},
+				},
+			},
+			isNormalTest: true,
+		},
+		{
+			name:   "dummy-prod-ag already instance",
+			input1: "dummy-prod-ag",
+			input2: "dummy-prod-app",
+			input3: "i-aaaaaa",
+			input4: "192.0.2.11",
+			expected: halib.InstanceData{
+				InstanceID: "",
+				IP:         "",
+				MetricPlugins: []struct {
+					PluginName   string `json:"plugin_name"`
+					PluginOption string `json:"plugin_option"`
+				}(nil),
+			},
+			isNormalTest: false,
+		},
+		{
+			name:   "dummy-stg-ag no empty alias",
+			input1: "dummy-stg-ag",
+			input2: "dummy-stg-app",
+			input3: "i-zzzzzz",
+			input4: "192.0.2.99",
+			expected: halib.InstanceData{
+				InstanceID: "",
+				IP:         "",
+				MetricPlugins: []struct {
+					PluginName   string `json:"plugin_name"`
+					PluginOption string `json:"plugin_option"`
+				}(nil),
+			},
+			isNormalTest: false,
+		},
+		{
+			name:   "dummy-missing-ag",
+			input1: "dummy-missing-ag",
+			input2: "dummy-missing-app",
+			input3: "i-zzzzzz",
+			input4: "192.0.2.99",
+			expected: halib.InstanceData{
+				InstanceID: "",
+				IP:         "",
+				MetricPlugins: []struct {
+					PluginName   string `json:"plugin_name"`
+					PluginOption string `json:"plugin_option"`
+				}(nil),
+			},
+			isNormalTest: false,
+		},
+	}
+
+	client := &AWSClient{
+		svcEC2:         &mockEC2Client{},
+		svcAutoscaling: &mockAutoScalingClient{},
+	}
+	RefreshAutoScalingInstances(client, "dummy-prod-ag", "dummy-prod-app", 20)
+	RefreshAutoScalingInstances(client, "dummy-stg-ag", "dummy-stg-app", 4)
+	defer teardown()
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := RegisterAutoScalingInstance(c.input1, c.input2, c.input3, c.input4)
+			assert.Equal(t, c.expected, actual)
+			if c.isNormalTest {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+			}
+		})
+	}
+}
+
 func TestDeregisterAutoScalingInstance(t *testing.T) {
 	var cases = []struct {
 		name         string

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -146,6 +146,7 @@ func CmdDaemon(c *cli.Context) {
 	m.Post("/metric/config/update", binding.Json(halib.MetricConfigUpdateRequest{}), model.MetricConfigUpdate)
 	m.Post("/autoscaling/refresh", binding.Json(halib.AutoScalingRefreshRequest{}), model.AutoScalingRefresh)
 	m.Post("/autoscaling/delete", binding.Json(halib.AutoScalingDeleteRequest{}), model.AutoScalingDelete)
+	m.Post("/autoscaling/instance/register", binding.Json(halib.AutoScalingInstanceRegisterRequest{}), model.AutoScalingInstanceRegister)
 	m.Post("/autoscaling/instance/deregister", binding.Json(halib.AutoScalingInstanceDeregisterRequest{}), model.AutoScalingInstanceDeregister)
 	m.Post("/autoscaling/config/update", binding.Json(halib.AutoScalingConfigUpdateRequest{}), model.AutoScalingConfigUpdate)
 	m.Get("/autoscaling", model.AutoScaling)

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -176,6 +176,7 @@ type AutoScalingDeleteResponse struct {
 type AutoScalingInstanceRegisterResponse struct {
 	Status       string       `json:"status"`
 	Message      string       `json:"message"`
+	Alias        string       `json:"alias"`
 	InstanceData InstanceData `json:"instance_data"`
 }
 

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -97,6 +97,13 @@ type AutoScalingDeleteRequest struct {
 	AutoScalingGroupName string `json:"autoscaling_group_name"`
 }
 
+// AutoScalingInstanceRegisterRequest is /autoscaling/instance/register API
+type AutoScalingInstanceRegisterRequest struct {
+	APIKey     string `json:"apikey"`
+	InstanceID string `json:"instance_id"`
+	IP         string `json:"ip"`
+}
+
 // AutoScalingInstanceDeregisterRequest is /autoscaling/instance/delete API
 type AutoScalingInstanceDeregisterRequest struct {
 	APIKey     string `json:"apikey"`
@@ -162,6 +169,13 @@ type AutoScalingRefreshResponse struct {
 type AutoScalingDeleteResponse struct {
 	Status  string `json:"status"`
 	Message string `json:"message"`
+}
+
+// AutoScalingInstanceRegisterResponse is /autoscaling/instance/register API
+type AutoScalingInstanceRegisterResponse struct {
+	Status       string       `json:"status"`
+	Message      string       `json:"message"`
+	InstanceData InstanceData `json:"instance_data"`
 }
 
 // AutoScalingInstanceDeregisterResponse is /autoscaling/instance/delete API

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -99,9 +99,10 @@ type AutoScalingDeleteRequest struct {
 
 // AutoScalingInstanceRegisterRequest is /autoscaling/instance/register API
 type AutoScalingInstanceRegisterRequest struct {
-	APIKey     string `json:"apikey"`
-	InstanceID string `json:"instance_id"`
-	IP         string `json:"ip"`
+	APIKey               string `json:"apikey"`
+	InstanceID           string `json:"instance_id"`
+	IP                   string `json:"ip"`
+	AutoScalingGroupName string `json:"autoscaling_group_name"`
 }
 
 // AutoScalingInstanceDeregisterRequest is /autoscaling/instance/delete API

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -76,7 +76,7 @@ func AutoScalingInstanceRegister(request halib.AutoScalingInstanceRegisterReques
 	}
 
 	if err := autoscaling.RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, request.InstanceID, request.IP); err != nil {
-		response.Status = "NG"
+		response.Status = "error"
 		response.Message = err.Error()
 		r.JSON(http.StatusInternalServerError, response)
 		return

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -75,12 +75,16 @@ func AutoScalingInstanceRegister(request halib.AutoScalingInstanceRegisterReques
 		return
 	}
 
-	if err := autoscaling.RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, request.InstanceID, request.IP); err != nil {
+	instanceData, err := autoscaling.RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, request.InstanceID, request.IP)
+	if err != nil {
 		response.Status = "error"
 		response.Message = err.Error()
 		r.JSON(http.StatusInternalServerError, response)
 		return
 	}
+
+	response.Status = "OK"
+	response.InstanceData = instanceData
 
 	r.JSON(http.StatusOK, response)
 }

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -40,6 +40,20 @@ func AutoScalingConfigUpdate(autoScalingRequest halib.AutoScalingConfigUpdateReq
 	r.JSON(http.StatusOK, autoScalingResponse)
 }
 
+// AutoScalingInstanceRegister register autoscaling instance to dbms
+func AutoScalingInstanceRegister(request halib.AutoScalingInstanceRegisterRequest, r render.Render) {
+	var response halib.AutoScalingInstanceRegisterResponse
+
+	if err := autoscaling.RegisterAutoScalingInstance(request.InstanceID); err != nil {
+		response.Status = "NG"
+		response.Message = err.Error()
+		r.JSON(http.StatusInternalServerError, response)
+		return
+	}
+
+	r.JSON(http.StatusOK, response)
+}
+
 // AutoScalingInstanceDeregister deregister autoscaling instance from dbms
 func AutoScalingInstanceDeregister(request halib.AutoScalingInstanceDeregisterRequest, r render.Render) {
 	var response halib.AutoScalingInstanceDeregisterResponse

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -75,7 +75,7 @@ func AutoScalingInstanceRegister(request halib.AutoScalingInstanceRegisterReques
 		return
 	}
 
-	instanceData, err := autoscaling.RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, request.InstanceID, request.IP)
+	alias, instanceData, err := autoscaling.RegisterAutoScalingInstance(autoScalingGroupName, hostPrefix, request.InstanceID, request.IP)
 	if err != nil {
 		response.Status = "error"
 		response.Message = err.Error()
@@ -84,6 +84,7 @@ func AutoScalingInstanceRegister(request halib.AutoScalingInstanceRegisterReques
 	}
 
 	response.Status = "OK"
+	response.Alias = alias
 	response.InstanceData = instanceData
 
 	r.JSON(http.StatusOK, response)


### PR DESCRIPTION
Added new endpoint `/autoscale/instance/register`.
When do API request with parameter to this endpoint, happo-agent register instance data with dbms.

I thinking of using this endpoint when AutoScaling instance register self instance data after launch.