### PR TITLE
Add helper scripts for testing with docker on local

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -274,6 +274,11 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/metric/status
 1. Run `gofmt -s`
 1. Create a new Pull Request
 
+### Run test suite with docker
+
+ローカルPC上のDockerでテストスイートを実行することもできます。
+
+[ヘルパースクリプトの使用法](contrib/development/README.md)を参照してください。
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,11 @@ $ wget -q --no-check-certificate -O - https://127.0.0.1:6777/machine-state/s-149
 1. Run `gofmt -s`
 1. Create a new Pull Request
 
+### Run test suite with docker
+
+You also can run test suite with docker on local PC.
+
+See [helper scripts usage](contrib/development/README.md)
 
 ## Author
 

--- a/contrib/development/README.md
+++ b/contrib/development/README.md
@@ -1,0 +1,49 @@
+# How to use docker in local development environment
+
+- Requirements
+    - Docker
+- Local Requirements
+    - yq ( use at Setup (to specify docker image name) )
+    - jq ( yq requires jq )
+
+Local Workdir is project root ( same as main.go )
+
+## Setup
+
+```
+docker run --rm -it -d --security-opt=seccomp:unconfined -v $(pwd):/mnt -p 6777:6777 -p 2345:2345 --name=happo-agent-dev $(cat wercker.yml | yq ".box" -r) /mnt/contrib/development/docker_run.sh
+```
+
+=> may took few minutes. if you want to know progress, use `docker logs -f happo-agent-dev`
+
+## Run all test
+
+```
+docker exec -it happo-agent-dev /mnt/contrib/development/docker_exec_test.sh
+```
+
+## Run specified test(ex: in case collect package)
+
+```
+docker exec -it -w /go/src/github.com/heartbeatsjp/happo-agent happo-agent-dev go test ./collect/...
+```
+
+## Debug with gdb-like shell (ex: in case `daemon` subcommand)
+
+```
+docker exec -it -w /go/src/github.com/heartbeatsjp/happo-agent happo-agent-dev dlv debug -- daemon -A 0.0.0.0/0 -B /go/happo-agent.pub -R /go/happo-agent.key -M /go/metrics.yaml
+```
+
+
+## Debug with remote (ex: in case `daemon` subcommand)
+
+```
+docker exec -it -w /go/src/github.com/heartbeatsjp/happo-agent happo-agent-dev dlv debug --headless --listen=:2345 --log -- daemon -A 0.0.0.0/0 -B /go/happo-agent.pub -R /go/happo-agent.key -M /go/metrics.yaml
+```
+
+## How to see happo-agent.log
+
+```
+docker exec -it -w /go/src/github.com/heartbeatsjp/happo-agent happo-agent-dev tail -F happo-agent.log
+```
+

--- a/contrib/development/docker_exec_test.sh
+++ b/contrib/development/docker_exec_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+export PATH=$PATH:/usr/local/bin
+
+if [[ ! -f /root/setup ]]; then
+    echo "ERROR: setup not yet finished. retry after few seconds."
+    exit 1
+fi
+
+cd /go/src/github.com/heartbeatsjp/happo-agent/
+echo "### rsync"
+rsync -av --delete --exclude="vendor" --exclude=".wercker" /mnt/ /go/src/github.com/heartbeatsjp/happo-agent/
+echo
+
+echo "### wercker steps"
+
+echo "cd /go/src/github.com/heartbeatsjp/happo-agent/; $(cat /mnt/wercker.yml | yq '.build.steps[:-1][].script.code' -r | grep -v '^null$')" | bash -xe

--- a/contrib/development/docker_run.sh
+++ b/contrib/development/docker_run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cd /go
+mkdir -p src/github.com/heartbeatsjp/happo-agent || :
+apt-get update
+apt-get -y install rsync python-pip jq nagios-plugins
+pip install yq
+
+curl -L -o /tmp/mackerel-plugins.deb https://github.com/mackerelio/mackerel-agent-plugins/releases/download/v0.49.0/mackerel-agent-plugins_0.49.0-1.v2_amd64.deb
+dpkg -i /tmp/mackerel-plugins.deb
+ln -s /usr/bin/mackerel-plugin* /usr/local/bin/.
+
+install -d -m 755 /root/.ssh
+cat << EOT | tee /root/.ssh/config
+Host *
+    UserKnownHostsFile /dev/null
+    StrictHostKeyChecking no
+EOT
+
+openssl genrsa -out happo-agent.key 2048
+yes "" | openssl req -new -key happo-agent.key -sha256 -out happo-agent.csr
+openssl x509 -in happo-agent.csr -days 3650 -req -signkey happo-agent.key -sha256 -out happo-agent.pub
+touch metrics.yaml
+
+touch /root/setup
+
+echo "all things done. start..."
+exec /bin/bash


### PR DESCRIPTION
Add helper scripts for testing with docker on local.

These scripts are based on `wercker.yml` . we use these scripts while development happo-agent.
