### PR TITLE
Fix #35 When timeout occured while collectiong metrics, does NOT abort collect metrics.

### DIFF
--- a/collect/metrics.go
+++ b/collect/metrics.go
@@ -216,6 +216,11 @@ func getMetrics(pluginName string, pluginOption string) (string, error) {
 	exitstatus, stdout, _, err := util.ExecCommand(plugin, pluginOption)
 
 	if err != nil {
+		// timeout is onetime/runtime error, does not handle as serious error
+		if timeoutError, ok := err.(*util.TimeoutError); ok {
+			log.Errorf("Plugin timeout: %s %s", pluginName, timeoutError.Error())
+			return stdout, nil
+		}
 		return "", err
 	}
 	if exitstatus != 0 {

--- a/collect/metrics_test.go
+++ b/collect/metrics_test.go
@@ -1,12 +1,14 @@
 package collect
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-agent/halib"
+	"github.com/heartbeatsjp/happo-agent/util"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -76,6 +78,18 @@ func TestGetMetrics1(t *testing.T) {
 func TestGetMetrics2(t *testing.T) {
 	_, err := getMetrics("dummy", "")
 	assert.Nil(t, err) // If plugin not found, not stop app.
+}
+
+func TestGetMetrics3(t *testing.T) {
+	SensuPluginPaths = fmt.Sprintf("%s,/usr/bin,/bin", SensuPluginPaths)
+	prevCommandTimeout := util.CommandTimeout
+
+	util.CommandTimeout = 1
+	_, err := getMetrics("sleep", "2")
+
+	util.CommandTimeout = prevCommandTimeout
+
+	assert.Nil(t, err)
 }
 
 func TestParseMetricData1(t *testing.T) {


### PR DESCRIPTION
Fix #35 

- Plugin timeout is almost onetime, transient issue.
- One plugin blocks all metrics is not good behavior.

After merged, metrics collection continues from next plugin.