### PR TITLE
Autoscaling proxy monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ Use agent bastion(proxy) mode.
 
 In case `--proxy-timeout-seconds` reached, return `504 Gateway Timeout` .
 
+If destination host is AutoScaling instance, it will behave as follows.
+
+- `request_type: monitor` 
+    - In case it can be resolved alias, proxy request to Auto Scaling instance.
+    - In case it can't be resolved alias, return dummy response from bastion.
+        - dummy response: `{"return_value":0,"message":"<alias> has not been assigned Instance\n"}`
+
 ```
 $ wget -q --no-check-certificate -O - https://192.0.2.1:6777/proxy --post-data='{"proxy_hostport": ["198.51.100.1:6777"], "request_type": "monitor", "request_json": "{\"apikey\": \"\", \"plugin_name\": \"check_procs\", \"plugin_option\": \"-w 100 -c 200\"}"}'
 {"return_value":1,"message":"PROCS WARNING: 168 processes\n"}

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -424,3 +424,17 @@ func DeleteAutoScaling(autoScalingGroupName string) error {
 
 	return nil
 }
+
+// AliasToIP resolve autoscaling instance private ip address
+func AliasToIP(alias string) (string, error) {
+	value, err := db.DB.Get([]byte(fmt.Sprintf("ag-%s", alias)), nil)
+	if err != nil {
+		return "", err
+	}
+	var instanceData halib.InstanceData
+	dec := gob.NewDecoder(bytes.NewReader(value))
+	if err := dec.Decode(&instanceData); err != nil {
+		return "", err
+	}
+	return instanceData.IP, nil
+}

--- a/halib/constant.go
+++ b/halib/constant.go
@@ -60,3 +60,6 @@ const DefaultMetricsConfigPath = "./metrics.yaml"
 
 // DefaultAutoScalingConfigPath is default autoscaling config path
 const DefaultAutoScalingConfigPath = "./autoscaling.yaml"
+
+// DefaultRefreshAutoScalingIntervalSeconds when proxy monitor return not http.StatusOK), and refreshAutoScalingIntervalSeconds past from previous error, refresh AutoScaling instances.
+const DefaultRefreshAutoScalingIntervalSeconds = 60

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -39,6 +39,13 @@ type AutoScalingData struct {
 	} `json:"instances"`
 }
 
+// AutoScalingConfigData is actual autoscaling config data
+type AutoScalingConfigData struct {
+	AutoScalingGroupName string `json:"autoscaling_group_name"`
+	AutoScalingCount     int    `json:"autoscaling_count"`
+	HostPrefix           string `json:"host_prefix"`
+}
+
 // --- Request Parameter
 
 // ProxyRequest is /proxy API

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -195,6 +195,8 @@ func monitorAutoScaling(host string, port int, requestType string, jsonData []by
 
 func postToAutoScalingAgent(host string, port int, requestType string, jsonData []byte, autoScalingGroupName string) (int, string, error) {
 	switch requestType {
+	case "":
+		return http.StatusBadRequest, "request_type required", nil
 	case "monitor":
 		return monitorAutoScaling(host, port, requestType, jsonData, autoScalingGroupName)
 	// TODO: implement for other requestType

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -41,7 +41,7 @@ func init() {
 			select {
 			case a := <-refreshAutoScalingChan:
 				go func(autoScalingGroupName, hostPrefix string, autoScalingCount int) {
-					if isPermitRefreshAutoScaling(a.AutoScalingGroupName) {
+					if isPermitRefreshAutoScaling(autoScalingGroupName) {
 						client := autoscaling.NewAWSClient()
 						if err := autoscaling.RefreshAutoScalingInstances(client, autoScalingGroupName, hostPrefix, autoScalingCount); err != nil {
 							log := util.HappoAgentLogger()

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -116,7 +116,7 @@ func getAutoScalingInfo(nextHost string) (halib.AutoScalingConfigData, error) {
 	}
 
 	for _, a := range autoScalingList.AutoScalings {
-		if strings.HasPrefix(nextHost, a.AutoScalingGroupName) {
+		if strings.HasPrefix(nextHost, fmt.Sprintf("%s-%s-", a.AutoScalingGroupName, a.HostPrefix)) {
 			autoScalingConfigData.AutoScalingGroupName = a.AutoScalingGroupName
 			autoScalingConfigData.HostPrefix = a.HostPrefix
 			autoScalingConfigData.AutoScalingCount = a.AutoScalingCount

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -207,13 +207,13 @@ func postToAutoScalingAgent(host string, port int, requestType string, jsonData 
 
 func isPermitRefreshAutoScaling(autoScalingGroupName string) bool {
 	log := util.HappoAgentLogger()
-	if _, ok := lastRefreshAutoScaling[autoScalingGroupName]; !ok {
-		lastRefreshAutoScaling[autoScalingGroupName] = 0
-	}
 
 	refreshAutoScalingMutex.Lock()
 	defer refreshAutoScalingMutex.Unlock()
 
+	if _, ok := lastRefreshAutoScaling[autoScalingGroupName]; !ok {
+		lastRefreshAutoScaling[autoScalingGroupName] = 0
+	}
 	duration := time.Now().Unix() - lastRefreshAutoScaling[autoScalingGroupName]
 	if duration < refreshAutoScalingIntervalSeconds {
 		log.Debug(fmt.Sprintf("Duration of after last refresh autoscaling: %d < %d", duration, refreshAutoScalingIntervalSeconds))

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -195,14 +195,11 @@ func monitorAutoScaling(host string, port int, requestType string, jsonData []by
 
 func postToAutoScalingAgent(host string, port int, requestType string, jsonData []byte, autoScalingGroupName string) (int, string, error) {
 	switch requestType {
-	case "":
-		return http.StatusBadRequest, "request_type required", nil
 	case "monitor":
 		return monitorAutoScaling(host, port, requestType, jsonData, autoScalingGroupName)
 	// TODO: implement for other requestType
 	default:
-		// don't work
-		return postToAgent(host, port, requestType, jsonData)
+		return http.StatusBadRequest, "request_type unsupported", nil
 	}
 }
 

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -147,12 +147,12 @@ func monitorAutoScaling(host string, port int, requestType string, jsonData []by
 		} else {
 			message = err.Error()
 		}
-		return http.StatusOK, makeMonitorResponse(3, message), nil
+		return http.StatusOK, makeMonitorResponse(halib.MonitorUnknown, message), nil
 	}
 
 	if ip == "" {
 		message := fmt.Sprintf("%s has not been assigned Instance", host)
-		return http.StatusOK, makeMonitorResponse(0, message), nil
+		return http.StatusOK, makeMonitorResponse(halib.MonitorOK, message), nil
 	}
 
 	return postToAgent(ip, port, requestType, jsonData)

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -28,6 +28,7 @@ var _httpClient = &http.Client{Transport: tr}
 
 // Proxy do http reqest to next happo-agent
 func Proxy(proxyRequest halib.ProxyRequest, r render.Render) (int, string) {
+	log := util.HappoAgentLogger()
 	var nextHostport string
 	var requestType string
 	var requestJSON []byte
@@ -77,7 +78,9 @@ func Proxy(proxyRequest halib.ProxyRequest, r render.Render) (int, string) {
 	if respCode != http.StatusOK {
 		go func() {
 			client := autoscaling.NewAWSClient()
-			autoscaling.RefreshAutoScalingInstances(client, autoScalingGroupName, hostPrefix, autoScalingCount)
+			if err := autoscaling.RefreshAutoScalingInstances(client, autoScalingGroupName, hostPrefix, autoScalingCount); err != nil {
+				log.Error(err.Error())
+			}
 		}()
 	}
 

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -74,7 +74,7 @@ func Proxy(proxyRequest halib.ProxyRequest, r render.Render) (int, string) {
 		}
 	}
 
-	if respCode == http.StatusGatewayTimeout {
+	if respCode != http.StatusOK {
 		go func() {
 			client := autoscaling.NewAWSClient()
 			autoscaling.RefreshAutoScalingInstances(client, autoScalingGroupName, hostPrefix, autoScalingCount)

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -40,15 +40,15 @@ func init() {
 		for {
 			select {
 			case a := <-refreshAutoScalingChan:
-				go func() {
+				go func(autoScalingGroupName, hostPrefix string, autoScalingCount int) {
 					if isPermitRefreshAutoScaling(a.AutoScalingGroupName) {
 						client := autoscaling.NewAWSClient()
-						if err := autoscaling.RefreshAutoScalingInstances(client, a.AutoScalingGroupName, a.HostPrefix, a.AutoScalingCount); err != nil {
+						if err := autoscaling.RefreshAutoScalingInstances(client, autoScalingGroupName, hostPrefix, autoScalingCount); err != nil {
 							log := util.HappoAgentLogger()
 							log.Error(err.Error())
 						}
 					}
-				}()
+				}(a.AutoScalingGroupName, a.HostPrefix, a.AutoScalingCount)
 			}
 		}
 	}()

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -110,7 +110,7 @@ func getAutoScalingInfo(nextHost string) halib.AutoScalingConfigData {
 	var autoScalingConfigData halib.AutoScalingConfigData
 	autoScalingList, err := autoscaling.GetAutoScalingConfig(AutoScalingConfigFile)
 	if err != nil {
-		log.Errorf("failed to get autoscaling config: %s", err)
+		log.Errorf("failed to get autoscaling config: %s", err.Error())
 		return autoScalingConfigData
 	}
 
@@ -178,7 +178,7 @@ func monitorAutoScaling(host string, port int, requestType string, jsonData []by
 	}
 
 	if ip == "" {
-		message := fmt.Sprintf("%s has not been assigned Instance\n", host)
+		message := fmt.Sprintf("%s has not been assigned instance\n", host)
 		return http.StatusOK, makeMonitorResponse(halib.MonitorOK, message), nil
 	}
 

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -143,7 +143,7 @@ func monitorAutoScaling(host string, port int, requestType string, jsonData []by
 	if err != nil {
 		var message string
 		if err == leveldb.ErrNotFound {
-			message = fmt.Sprintf("alias not found: %s", host)
+			message = fmt.Sprintf("alias not found: %s\n", host)
 		} else {
 			message = err.Error()
 		}
@@ -151,7 +151,7 @@ func monitorAutoScaling(host string, port int, requestType string, jsonData []by
 	}
 
 	if ip == "" {
-		message := fmt.Sprintf("%s has not been assigned Instance", host)
+		message := fmt.Sprintf("%s has not been assigned Instance\n", host)
 		return http.StatusOK, makeMonitorResponse(halib.MonitorOK, message), nil
 	}
 

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -574,7 +574,7 @@ func TestProxy9(t *testing.T) {
 	m.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusBadRequest, res.Code)
-	assert.Equal(t, "request_type required", res.Body.String())
+	assert.Equal(t, "request_type unsupported", res.Body.String())
 }
 
 func TestMain(m *testing.M) {

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -11,12 +11,44 @@ import (
 	"testing"
 	"time"
 
+	"os"
+
 	"github.com/codegangsta/martini-contrib/render"
 	"github.com/go-martini/martini"
+	"github.com/heartbeatsjp/happo-agent/autoscaling"
+	"github.com/heartbeatsjp/happo-agent/autoscaling/awsmock"
+	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-agent/halib"
 	"github.com/martini-contrib/binding"
 	"github.com/stretchr/testify/assert"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	leveldbUtil "github.com/syndtr/goleveldb/leveldb/util"
 )
+
+func setup() {
+	//Mock
+	DB, err := leveldb.Open(storage.NewMemStorage(), nil)
+	if err != nil {
+		os.Exit(1)
+	}
+	db.DB = DB
+}
+
+func teardown() {
+	iter := db.DB.NewIterator(
+		leveldbUtil.BytesPrefix(
+			[]byte("ag-"),
+		),
+		nil,
+	)
+	for iter.Next() {
+		key := iter.Key()
+		db.DB.Delete(key, nil)
+	}
+	iter.Release()
+	db.DB.Close()
+}
 
 func TestPostToAgent1(t *testing.T) {
 	const stubResponse = "OK"
@@ -290,6 +322,56 @@ func TestProxy4(t *testing.T) {
 	assert.Equal(t, http.StatusGatewayTimeout, res.Code)
 	assert.Equal(t,
 		fmt.Sprintf(`{"return_value":3,"message":"Post https://%s:%d/proxy: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}`, host, port),
+		res.Body.String(),
+	)
+}
+
+func TestProxy5(t *testing.T) {
+	//dispatch autoscaling instance
+
+	setup()
+	client := &autoscaling.AWSClient{
+		SvcEC2:         &awsmock.MockEC2Client{},
+		SvcAutoscaling: &awsmock.MockAutoScalingClient{},
+	}
+	autoscaling.RefreshAutoScalingInstances(client, "dummy-prod-ag", "dummy-prod-app", 10)
+	defer teardown()
+
+	//bastion
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+
+	//edge
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"return_value":0,"message":"ok"}`)
+			}))
+	ts.URL = "http://192.0.2.11:6777"
+	defer ts.Close()
+
+	alias := "dummy-prod-ag-dummy-prod-app-1"
+	port := 6777
+
+	requestJSON := fmt.Sprintf(`{
+		"proxy_hostport": ["%s:%d"],
+		"request_type": "monitor",
+		"request_json":
+			"{\"apikey\": \"\", \"plugin_name\": \"monitor_test_plugin\", \"plugin_option\": \"0\"}"
+	}`, alias, port)
+	reader := bytes.NewReader([]byte(requestJSON))
+
+	req, _ := http.NewRequest("POST", "/proxy", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t,
+		`{"return_value":0,"message":"ok"}`,
 		res.Body.String(),
 	)
 }

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -439,7 +439,7 @@ func TestProxy6(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t,
-		`{"return_value":0,"message":"dummy-prod-ag-dummy-prod-app-2 has not been assigned Instance\n"}`,
+		`{"return_value":0,"message":"dummy-prod-ag-dummy-prod-app-2 has not been assigned instance\n"}`,
 		res.Body.String(),
 	)
 }

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -365,7 +365,7 @@ func TestProxy5(t *testing.T) {
 	ts := httptest.NewTLSServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprint(w, `{"return_value":0,"message":"ok"}`)
+				fmt.Fprint(w, `{"return_value":0,"message":"ok\n"}`)
 			}))
 	defer ts.Close()
 
@@ -392,7 +392,7 @@ func TestProxy5(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t,
-		`{"return_value":0,"message":"ok"}`,
+		`{"return_value":0,"message":"ok\nAutoScaling Group Name: dummy-prod-ag\nAutoScaling Instance PrivateIP: 127.0.0.1\n"}`,
 		res.Body.String(),
 	)
 }
@@ -412,7 +412,7 @@ func TestProxy6(t *testing.T) {
 	ts := httptest.NewTLSServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprint(w, `{"return_value":0,"message":"ok"}`)
+				fmt.Fprint(w, `{"return_value":0,"message":"ok\n"}`)
 			}))
 	defer ts.Close()
 
@@ -439,7 +439,7 @@ func TestProxy6(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t,
-		`{"return_value":0,"message":"dummy-prod-ag-dummy-prod-app-2 has not been assigned Instance"}`,
+		`{"return_value":0,"message":"dummy-prod-ag-dummy-prod-app-2 has not been assigned Instance\n"}`,
 		res.Body.String(),
 	)
 }
@@ -459,7 +459,7 @@ func TestProxy7(t *testing.T) {
 	ts := httptest.NewTLSServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprint(w, `{"return_value":0,"message":"ok"}`)
+				fmt.Fprint(w, `{"return_value":0,"message":"ok\n"}`)
 			}))
 	defer ts.Close()
 
@@ -486,7 +486,7 @@ func TestProxy7(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t,
-		`{"return_value":3,"message":"alias not found: dummy-prod-ag-dummy-prod-app-99"}`,
+		`{"return_value":3,"message":"alias not found: dummy-prod-ag-dummy-prod-app-99\n"}`,
 		res.Body.String(),
 	)
 }


### PR DESCRIPTION
`/proxy` support AutoScaling. it behave when destination hostname prefix is match to `<AutoScaling Groupname>-<hostprefix>-`

- In case it can be resolved alias, proxy request to Auto Scaling instance.
- In case it can't be resolved alias, return dummy response from bastion.
    - dummy response: `{"return_value":0,"message":"<alias> has not been assigned Instance\n"}`
- If failed monitor request to AutoScaling instance, execute refresh AutoScaling instances.

@netmarkjp  Please review.