### PR TITLE
Autoscaling proxy metric

### DIFF
--- a/model/proxy.go
+++ b/model/proxy.go
@@ -203,7 +203,7 @@ func metricAutoScaling(host string, port int, requestType string, jsonData []byt
 	}
 
 	if ip == "" {
-		return http.StatusNotFound, fmt.Sprintf("%s has not been assigned instance\n", host), nil
+		return http.StatusServiceUnavailable, fmt.Sprintf("%s has not been assigned instance\n", host), nil
 	}
 
 	return postToAgent(ip, port, requestType, jsonData)

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -659,7 +659,7 @@ func TestProxy11(t *testing.T) {
 
 	m.ServeHTTP(res, req)
 
-	assert.Equal(t, http.StatusNotFound, res.Code)
+	assert.Equal(t, http.StatusServiceUnavailable, res.Code)
 	assert.Equal(t, "dummy-prod-ag-dummy-prod-app-2 has not been assigned instance\n", res.Body.String())
 }
 

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -577,6 +577,135 @@ func TestProxy9(t *testing.T) {
 	assert.Equal(t, "request_type unsupported", res.Body.String())
 }
 
+func TestProxy10(t *testing.T) {
+	//proxy metric when alias assigned instance
+
+	setup()
+	defer teardown()
+
+	//bastion
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+
+	//edge
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"metric_data":null,"message":""}`)
+			}))
+	defer ts.Close()
+
+	re, _ := regexp.Compile("([a-z]+)://([A-Za-z0-9.]+):([0-9]+)(.*)")
+	found := re.FindStringSubmatch(ts.URL)
+	port, _ := strconv.Atoi(found[3])
+
+	alias := "dummy-prod-ag-dummy-prod-app-1"
+
+	requestJSON := fmt.Sprintf(`{
+		"proxy_hostport": ["%s:%d"],
+		"request_type": "metric",
+		"request_json": "{\"apikey\": \"\"}"
+	}`, alias, port)
+	reader := bytes.NewReader([]byte(requestJSON))
+
+	req, _ := http.NewRequest("POST", "/proxy", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, `{"metric_data":null,"message":""}`, res.Body.String())
+}
+
+func TestProxy11(t *testing.T) {
+	//proxy metric when alias not assigned instance
+
+	setup()
+	defer teardown()
+
+	//bastion
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+
+	//edge
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"metric_data":null,"message":""}`)
+			}))
+	defer ts.Close()
+
+	re, _ := regexp.Compile("([a-z]+)://([A-Za-z0-9.]+):([0-9]+)(.*)")
+	found := re.FindStringSubmatch(ts.URL)
+	port, _ := strconv.Atoi(found[3])
+
+	alias := "dummy-prod-ag-dummy-prod-app-2"
+
+	requestJSON := fmt.Sprintf(`{
+		"proxy_hostport": ["%s:%d"],
+		"request_type": "metric",
+		"request_json": "{\"apikey\": \"\"}"
+	}`, alias, port)
+	reader := bytes.NewReader([]byte(requestJSON))
+
+	req, _ := http.NewRequest("POST", "/proxy", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusNotFound, res.Code)
+	assert.Equal(t, "dummy-prod-ag-dummy-prod-app-2 has not been assigned instance\n", res.Body.String())
+}
+
+func TestProxy12(t *testing.T) {
+	//proxy metric when alias not found
+
+	setup()
+	defer teardown()
+
+	//bastion
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+
+	//edge
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"metric_data":null,"message":""}`)
+			}))
+	defer ts.Close()
+
+	re, _ := regexp.Compile("([a-z]+)://([A-Za-z0-9.]+):([0-9]+)(.*)")
+	found := re.FindStringSubmatch(ts.URL)
+	port, _ := strconv.Atoi(found[3])
+
+	alias := "dummy-prod-ag-dummy-prod-app-99"
+
+	requestJSON := fmt.Sprintf(`{
+		"proxy_hostport": ["%s:%d"],
+		"request_type": "metric",
+		"request_json": "{\"apikey\": \"\"}"
+	}`, alias, port)
+	reader := bytes.NewReader([]byte(requestJSON))
+
+	req, _ := http.NewRequest("POST", "/proxy", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusNotFound, res.Code)
+	assert.Equal(t, "alias not found: dummy-prod-ag-dummy-prod-app-99\n", res.Body.String())
+}
+
 func TestMain(m *testing.M) {
 	AutoScalingConfigFile = "../autoscaling/testdata/autoscaling_test.yaml"
 	os.Exit(m.Run())


### PR DESCRIPTION
This patch implements proxy metric request to AutoScaling instance.

- In case it can be resolved alias, proxy request to Auto Scaling instance.
- In case it can't be resolved alias, return HTTP status 404 response from bastion.

@netmarkjp 
Please review.