### PR TITLE
modify instanceData structure

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -309,15 +309,7 @@ func RefreshAutoScalingInstances(client *AWSClient, autoScalingGroupName, hostPr
 				var instanceData halib.InstanceData
 				instanceData.InstanceID = *autoScalingInstance.InstanceId
 				instanceData.IP = *autoScalingInstance.PrivateIpAddress
-				instanceData.MetricPlugins = []struct {
-					PluginName   string `json:"plugin_name"`
-					PluginOption string `json:"plugin_option"`
-				}{
-					{
-						PluginName:   "",
-						PluginOption: "",
-					},
-				}
+				instanceData.MetricConfig = halib.MetricConfig{}
 				newInstances = append(newInstances, instanceData)
 			}
 		}
@@ -327,7 +319,7 @@ func RefreshAutoScalingInstances(client *AWSClient, autoScalingGroupName, hostPr
 				key := fmt.Sprintf("ag-%s-%s-%d", autoScalingGroupName, hostPrefix, i+1)
 				if _, ok := actualInstances[key]; !ok {
 					if _, ok := registeredInstances[key]; ok {
-						instance.MetricPlugins = registeredInstances[key].MetricPlugins
+						instance.MetricConfig = registeredInstances[key].MetricConfig
 					}
 					actualInstances[key] = instance
 					break
@@ -339,22 +331,14 @@ func RefreshAutoScalingInstances(client *AWSClient, autoScalingGroupName, hostPr
 	// fill actualInstances with emptyInstance
 	for i := 0; i < autoscalingCount; i++ {
 		emptyInstance := halib.InstanceData{
-			InstanceID: "",
-			IP:         "",
-			MetricPlugins: []struct {
-				PluginName   string `json:"plugin_name"`
-				PluginOption string `json:"plugin_option"`
-			}{
-				{
-					PluginName:   "",
-					PluginOption: "",
-				},
-			},
+			InstanceID:   "",
+			IP:           "",
+			MetricConfig: halib.MetricConfig{},
 		}
 		key := fmt.Sprintf("ag-%s-%s-%d", autoScalingGroupName, hostPrefix, i+1)
 		if _, ok := actualInstances[key]; !ok {
 			if _, ok := registeredInstances[key]; ok {
-				emptyInstance.MetricPlugins = registeredInstances[key].MetricPlugins
+				emptyInstance.MetricConfig = registeredInstances[key].MetricConfig
 			}
 			actualInstances[key] = emptyInstance
 		}

--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -280,17 +280,9 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 			}{
 				alias: "dummy-prod-ag-dummy-prod-app-11",
 				instanceData: halib.InstanceData{
-					InstanceID: "i-zzzzzz",
-					IP:         "192.0.2.99",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-zzzzzz",
+					IP:           "192.0.2.99",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 			isNormalTest: true,
@@ -307,12 +299,9 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 			}{
 				alias: "",
 				instanceData: halib.InstanceData{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}(nil),
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 			isNormalTest: false,
@@ -329,12 +318,9 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 			}{
 				alias: "",
 				instanceData: halib.InstanceData{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}(nil),
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 			isNormalTest: false,
@@ -351,12 +337,9 @@ func TestRegisterAutoScalingInstance(t *testing.T) {
 			}{
 				alias: "",
 				instanceData: halib.InstanceData{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}(nil),
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 			isNormalTest: false,
@@ -438,134 +421,54 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 			input3: 10,
 			expected: []halib.InstanceData{
 				{
-					InstanceID: "i-aaaaaa",
-					IP:         "192.0.2.11",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-aaaaaa",
+					IP:           "192.0.2.11",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-jjjjjj",
-					IP:         "192.0.2.20",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-jjjjjj",
+					IP:           "192.0.2.20",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-bbbbbb",
-					IP:         "192.0.2.12",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-bbbbbb",
+					IP:           "192.0.2.12",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-cccccc",
-					IP:         "192.0.2.13",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-cccccc",
+					IP:           "192.0.2.13",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-dddddd",
-					IP:         "192.0.2.14",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-dddddd",
+					IP:           "192.0.2.14",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-eeeeee",
-					IP:         "192.0.2.15",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-eeeeee",
+					IP:           "192.0.2.15",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-ffffff",
-					IP:         "192.0.2.16",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-ffffff",
+					IP:           "192.0.2.16",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-gggggg",
-					IP:         "192.0.2.17",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-gggggg",
+					IP:           "192.0.2.17",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-hhhhhh",
-					IP:         "192.0.2.18",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-hhhhhh",
+					IP:           "192.0.2.18",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-iiiiii",
-					IP:         "192.0.2.19",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-iiiiii",
+					IP:           "192.0.2.19",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 		},
@@ -576,134 +479,54 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 			input3: 10,
 			expected: []halib.InstanceData{
 				{
-					InstanceID: "i-aaaaaa",
-					IP:         "192.0.2.11",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-aaaaaa",
+					IP:           "192.0.2.11",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-cccccc",
-					IP:         "192.0.2.13",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-cccccc",
+					IP:           "192.0.2.13",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-eeeeee",
-					IP:         "192.0.2.15",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-eeeeee",
+					IP:           "192.0.2.15",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-ffffff",
-					IP:         "192.0.2.16",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-ffffff",
+					IP:           "192.0.2.16",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-gggggg",
-					IP:         "192.0.2.17",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-gggggg",
+					IP:           "192.0.2.17",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-hhhhhh",
-					IP:         "192.0.2.18",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-hhhhhh",
+					IP:           "192.0.2.18",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-jjjjjj",
-					IP:         "192.0.2.20",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-jjjjjj",
+					IP:           "192.0.2.20",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 		},
@@ -714,56 +537,24 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 			input3: 4,
 			expected: []halib.InstanceData{
 				{
-					InstanceID: "i-kkkkkk",
-					IP:         "192.0.2.21",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-kkkkkk",
+					IP:           "192.0.2.21",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-llllll",
-					IP:         "192.0.2.22",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-llllll",
+					IP:           "192.0.2.22",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-mmmmmm",
-					IP:         "192.0.2.23",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-mmmmmm",
+					IP:           "192.0.2.23",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "i-nnnnnn",
-					IP:         "192.0.2.24",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "i-nnnnnn",
+					IP:           "192.0.2.24",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 		},
@@ -774,56 +565,24 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 			input3: 4,
 			expected: []halib.InstanceData{
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 		},
@@ -834,56 +593,24 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 			input3: 4,
 			expected: []halib.InstanceData{
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 		},
@@ -894,56 +621,24 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 			input3: 4,
 			expected: []halib.InstanceData{
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID: "",
-					IP:         "",
-					MetricPlugins: []struct {
-						PluginName   string `json:"plugin_name"`
-						PluginOption string `json:"plugin_option"`
-					}{
-						{
-							PluginName:   "",
-							PluginOption: "",
-						},
-					},
+					InstanceID:   "",
+					IP:           "",
+					MetricConfig: halib.MetricConfig{},
 				},
 			},
 		},

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -22,12 +22,9 @@ type InventoryData struct {
 
 // InstanceData is actual instance
 type InstanceData struct {
-	IP            string `json:"ip"`
-	InstanceID    string `json:"instance_id"`
-	MetricPlugins []struct {
-		PluginName   string `json:"plugin_name"`
-		PluginOption string `json:"plugin_option"`
-	} `json:"metric_plugins"`
+	IP           string       `json:"ip"`
+	InstanceID   string       `json:"instance_id"`
+	MetricConfig MetricConfig `json:"metric_config"`
 }
 
 // AutoScalingData name and actual instance data

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -38,15 +38,7 @@ func setup() {
 		var instanceData halib.InstanceData
 		instanceData.InstanceID = instanceID
 		instanceData.IP = ip
-		instanceData.MetricPlugins = []struct {
-			PluginName   string `json:"plugin_name"`
-			PluginOption string `json:"plugin_option"`
-		}{
-			{
-				PluginName:   "",
-				PluginOption: "",
-			},
-		}
+		instanceData.MetricConfig = halib.MetricConfig{}
 
 		var b bytes.Buffer
 		enc := gob.NewEncoder(&b)


### PR DESCRIPTION
This patch replace field `MetricPlugins` of `halib.InstanceData` to `MetricConfig`.

This field intended to use generate `metric.yaml` of AutoScaling instance. but `MetricPlugins` is not satisfy this use.
because `MetricPlugins` has not `hostname`, in case can't send all metrics info to instance when multiple `hostname` like follwing.

```yaml
metrics:
- hostname: hb-bastion
  plugins:
  - plugin_name: mackerel-plugin-linux
    plugin_option: ""
  - plugin_name: ng-monitor-plugin-linux-basic
    plugin_option: ""
- hostname: hb-app-RDS
  plugins:
  - plugin_name: mackerel-plugin-aws-rds
    plugin_option: -identifier hb-app-RDS -tempfile /tmp/mackerel-plugin-aws-rds
```