### PR TITLE
Autoscaling proxy metric config update

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -413,6 +413,10 @@ func DeleteAutoScaling(autoScalingGroupName string) error {
 func SaveAliasMetricConfig(alias string, metricConfig halib.MetricConfig) error {
 	log := util.HappoAgentLogger()
 
+	for i := 0; i < len(metricConfig.Metrics); i++ {
+		metricConfig.Metrics[i].Hostname = alias
+	}
+
 	transaction, err := db.DB.OpenTransaction()
 	if err != nil {
 		log.Error(err)

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -225,7 +225,15 @@ func metricConfigUpdateAutoScaling(host string, port int, requestType string, js
 	}
 
 	statusCode, jsonStr, perr := postToAgent(ip, port, requestType, jsonData)
-	if statusCode == http.StatusOK {
+
+	var m halib.MetricConfigUpdateResponse
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		return http.StatusInternalServerError, err.Error(), nil
+	}
+
+	// model.MetricConfigUpdate always return http status 200.
+	// so it also added `m.Status == "OK"` to condition.
+	if statusCode == http.StatusOK && m.Status == "OK" {
 		var m halib.MetricConfigUpdateRequest
 		if err := json.Unmarshal(jsonData, &m); err != nil {
 			log.Errorf("failed to save metric data: %s", err.Error())

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -266,7 +266,15 @@ func metricConfigUpdateAutoScaling(autoScalingGroupName string, port int, reques
 			continue
 		}
 
-		_, _, err := postToAgent(i.InstanceData.IP, port, requestType, jsonData)
+		jsonData, err := json.Marshal(metricConfigUpdateRequest)
+		if err != nil {
+			message := fmt.Sprintf("failed to post request at %s: %s", i.Alias, err.Error())
+			log.Error(message)
+			errStrings = append(errStrings, message)
+			continue
+		}
+
+		_, _, err = postToAgent(i.InstanceData.IP, port, requestType, jsonData)
 		if err != nil {
 			message := fmt.Sprintf("failed to post request at %s: %s", i.Alias, err.Error())
 			log.Error(message)

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -15,6 +15,8 @@ import (
 
 	"encoding/gob"
 
+	"encoding/json"
+
 	"github.com/codegangsta/martini-contrib/render"
 	"github.com/go-martini/martini"
 	"github.com/heartbeatsjp/happo-agent/db"
@@ -685,6 +687,173 @@ func TestProxy12(t *testing.T) {
 		"request_type": "metric",
 		"request_json": "{\"apikey\": \"\"}"
 	}`, alias, port)
+	reader := bytes.NewReader([]byte(requestJSON))
+
+	req, _ := http.NewRequest("POST", "/proxy", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusNotFound, res.Code)
+	assert.Equal(t, "alias not found: dummy-prod-ag-dummy-prod-app-99\n", res.Body.String())
+}
+
+func TestProxy13(t *testing.T) {
+	//proxy metric config update when alias assigned instance
+
+	setup()
+	defer teardown()
+
+	//bastion
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+
+	//edge
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"status":"OK","message":""}`)
+			}))
+	defer ts.Close()
+
+	re, _ := regexp.Compile("([a-z]+)://([A-Za-z0-9.]+):([0-9]+)(.*)")
+	found := re.FindStringSubmatch(ts.URL)
+	port, _ := strconv.Atoi(found[3])
+
+	alias := "dummy-prod-ag-dummy-prod-app-1"
+
+	var request halib.MetricConfigUpdateRequest
+	request.APIKey = ""
+	request.Config.Metrics = append(request.Config.Metrics, struct {
+		Hostname string `yaml:"hostname" json:"Hostname"`
+		Plugins  []struct {
+			PluginName   string `yaml:"plugin_name" json:"Plugin_Name"`
+			PluginOption string `yaml:"plugin_option" json:"Plugin_Option"`
+		} `yaml:"plugins" json:"Plugins"`
+	}{
+		"dummy-prod-ag-dummy-prod-app-1",
+		[]struct {
+			PluginName   string `yaml:"plugin_name" json:"Plugin_Name"`
+			PluginOption string `yaml:"plugin_option" json:"Plugin_Option"`
+		}{
+			{PluginName: "metric_test_plugin", PluginOption: "0"},
+		},
+	})
+	b, _ := json.Marshal(request)
+
+	var proxyRequest halib.ProxyRequest
+	proxyRequest.ProxyHostPort = append(proxyRequest.ProxyHostPort, fmt.Sprintf("%s:%d", alias, port))
+	proxyRequest.RequestType = "metric/config/update"
+	proxyRequest.RequestJSON = b
+	requestJSON, _ := json.Marshal(proxyRequest)
+
+	reader := bytes.NewReader([]byte(requestJSON))
+
+	req, _ := http.NewRequest("POST", "/proxy", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, `{"status":"OK","message":""}`, res.Body.String())
+}
+
+func TestProxy14(t *testing.T) {
+	//proxy metric config update when alias not assigned instance
+
+	setup()
+	defer teardown()
+
+	//bastion
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+
+	alias := "dummy-prod-ag-dummy-prod-app-2"
+	port := 6777
+
+	var request halib.MetricConfigUpdateRequest
+	request.APIKey = ""
+	request.Config.Metrics = append(request.Config.Metrics, struct {
+		Hostname string `yaml:"hostname" json:"Hostname"`
+		Plugins  []struct {
+			PluginName   string `yaml:"plugin_name" json:"Plugin_Name"`
+			PluginOption string `yaml:"plugin_option" json:"Plugin_Option"`
+		} `yaml:"plugins" json:"Plugins"`
+	}{
+		"dummy-prod-ag-dummy-prod-app-1",
+		[]struct {
+			PluginName   string `yaml:"plugin_name" json:"Plugin_Name"`
+			PluginOption string `yaml:"plugin_option" json:"Plugin_Option"`
+		}{
+			{PluginName: "metric_test_plugin", PluginOption: "0"},
+		},
+	})
+	b, _ := json.Marshal(request)
+
+	var proxyRequest halib.ProxyRequest
+	proxyRequest.ProxyHostPort = append(proxyRequest.ProxyHostPort, fmt.Sprintf("%s:%d", alias, port))
+	proxyRequest.RequestType = "metric/config/update"
+	proxyRequest.RequestJSON = b
+	requestJSON, _ := json.Marshal(proxyRequest)
+
+	reader := bytes.NewReader([]byte(requestJSON))
+
+	req, _ := http.NewRequest("POST", "/proxy", reader)
+	req.Header.Set("Content-Type", "application/json")
+
+	res := httptest.NewRecorder()
+
+	m.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, res.Code)
+	assert.Equal(t, "dummy-prod-ag-dummy-prod-app-2 has not been assigned instance\n", res.Body.String())
+}
+
+func TestProxy15(t *testing.T) {
+	//proxy metric config update when alias not found
+
+	setup()
+	defer teardown()
+
+	//bastion
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+
+	alias := "dummy-prod-ag-dummy-prod-app-99"
+	port := 6777
+
+	var request halib.MetricConfigUpdateRequest
+	request.APIKey = ""
+	request.Config.Metrics = append(request.Config.Metrics, struct {
+		Hostname string `yaml:"hostname" json:"Hostname"`
+		Plugins  []struct {
+			PluginName   string `yaml:"plugin_name" json:"Plugin_Name"`
+			PluginOption string `yaml:"plugin_option" json:"Plugin_Option"`
+		} `yaml:"plugins" json:"Plugins"`
+	}{
+		"dummy-prod-ag-dummy-prod-app-1",
+		[]struct {
+			PluginName   string `yaml:"plugin_name" json:"Plugin_Name"`
+			PluginOption string `yaml:"plugin_option" json:"Plugin_Option"`
+		}{
+			{PluginName: "metric_test_plugin", PluginOption: "0"},
+		},
+	})
+	b, _ := json.Marshal(request)
+
+	var proxyRequest halib.ProxyRequest
+	proxyRequest.ProxyHostPort = append(proxyRequest.ProxyHostPort, fmt.Sprintf("%s:%d", alias, port))
+	proxyRequest.RequestType = "metric/config/update"
+	proxyRequest.RequestJSON = b
+	requestJSON, _ := json.Marshal(proxyRequest)
+
 	reader := bytes.NewReader([]byte(requestJSON))
 
 	req, _ := http.NewRequest("POST", "/proxy", reader)

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -761,6 +761,14 @@ func TestProxy13(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t, `{"status":"OK","message":""}`, res.Body.String())
+
+	v, _ := db.DB.Get([]byte(fmt.Sprintf("ag-%s", alias)), nil)
+	var instanceData halib.InstanceData
+	dec := gob.NewDecoder(bytes.NewReader(v))
+	dec.Decode(&instanceData)
+	assert.Equal(t, "dummy-prod-ag-dummy-prod-app-1", instanceData.MetricConfig.Metrics[0].Hostname)
+	assert.Equal(t, "metric_test_plugin", instanceData.MetricConfig.Metrics[0].Plugins[0].PluginName)
+	assert.Equal(t, "0", instanceData.MetricConfig.Metrics[0].Plugins[0].PluginOption)
 }
 
 func TestProxy14(t *testing.T) {
@@ -813,6 +821,20 @@ func TestProxy14(t *testing.T) {
 
 	assert.Equal(t, http.StatusServiceUnavailable, res.Code)
 	assert.Equal(t, "dummy-prod-ag-dummy-prod-app-2 has not been assigned instance\n", res.Body.String())
+
+	v, _ := db.DB.Get([]byte(fmt.Sprintf("ag-%s", alias)), nil)
+	var instanceData halib.InstanceData
+	dec := gob.NewDecoder(bytes.NewReader(v))
+	dec.Decode(&instanceData)
+	assert.Equal(t, halib.MetricConfig{
+		Metrics: []struct {
+			Hostname string `yaml:"hostname" json:"Hostname"`
+			Plugins  []struct {
+				PluginName   string `yaml:"plugin_name" json:"Plugin_Name"`
+				PluginOption string `yaml:"plugin_option" json:"Plugin_Option"`
+			} `yaml:"plugins" json:"Plugins"`
+		}(nil),
+	}, instanceData.MetricConfig)
 }
 
 func TestProxy15(t *testing.T) {


### PR DESCRIPTION
This patch implements proxy `/metric/config/update` to AutoScaling instance.

- behave of proxy is same to other request type.
- proxy will update `MetricConfig` of instance data when request was successful.

@netmarkjp Please review.