### PR TITLE
subcommand resolve alias

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -322,6 +322,25 @@ $ wget -q --no-check-certificate -O -  https://127.0.0.1:6777/autoscaling
 {"autoscaling":[{"autoscaling_group_name":"hb-autoscaling","instances":[{"alias":"hb-autoscaling-app-1","instance_data":{"ip":"192.0.2.11","instance_id":"i-aaaaaaaaaaaaaaaaa","metric_plugins":[{"plugin_name":"","plugin_option":""}]}},{"alias":"hb-autoscaling-app-2","instance_data":{"ip":"192.0.2.12","instance_id":"i-bbbbbbbbbbbbbbbbb","metric_plugins":[{"plugin_name":"","plugin_option":""}]}},{"alias":"hb-autoscaling-app-3","instance_data":{"ip":"192.0.2.13","instance_id":"i-ccccccccccccccccc","metric_plugins":[{"plugin_name":"","plugin_option":""}]}},{"alias":"hb-autoscaling-app-4","instance_data":{"ip":"192.0.2.14","instance_id":"i-ddddddddddddddddd","metric_plugins":[{"plugin_name":"","plugin_option":""}]}}]}]}
 ```
 
+### /autoscaling/resolve/:alias
+
+エイリアスをプライベートIPアドレスに解決します。
+
+- 入力形式
+    - なし
+- 入力変数
+    - なし
+- 返り値の形式
+    - JSON
+- 返り値の変数
+    - status: 実行結果のステータス
+    - ip: プライベートIPアドレス
+
+```
+# wget -q --no-check-certificate -O -  https://127.0.0.1:6777/autoscaling/resolve/hb-autoscaling-app-1
+{"Status":"OK","ip":"192.0.2.11"}
+```
+
 ### /autoscaling/config/update
 
 AutoScalingの設定を更新します。

--- a/README.md
+++ b/README.md
@@ -322,6 +322,25 @@ $ wget -q --no-check-certificate -O -  https://127.0.0.1:6777/autoscaling
 {"autoscaling":[{"autoscaling_group_name":"hb-autoscaling","instances":[{"alias":"hb-autoscaling-app-1","instance_data":{"ip":"192.0.2.11","instance_id":"i-aaaaaaaaaaaaaaaaa","metric_plugins":[{"plugin_name":"","plugin_option":""}]}},{"alias":"hb-autoscaling-app-2","instance_data":{"ip":"192.0.2.12","instance_id":"i-bbbbbbbbbbbbbbbbb","metric_plugins":[{"plugin_name":"","plugin_option":""}]}},{"alias":"hb-autoscaling-app-3","instance_data":{"ip":"192.0.2.13","instance_id":"i-ccccccccccccccccc","metric_plugins":[{"plugin_name":"","plugin_option":""}]}},{"alias":"hb-autoscaling-app-4","instance_data":{"ip":"192.0.2.14","instance_id":"i-ddddddddddddddddd","metric_plugins":[{"plugin_name":"","plugin_option":""}]}}]}]}
 ```
 
+### /autoscaling/resolve/:alias
+
+Resolve ip from alias
+
+- Input format
+    - None
+- Input variables
+    - None
+- Return format
+    - JSON
+- Return variables
+    - status: result status
+    - ip: private ip address by Amazon EC2
+
+```
+# wget -q --no-check-certificate -O -  https://127.0.0.1:6777/autoscaling/resolve/hb-autoscaling-app-1
+{"Status":"OK","ip":"192.0.2.11"}
+```
+
 ### /autoscaling/config/update
 
 Update autoscaling config

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -150,6 +150,7 @@ func CmdDaemon(c *cli.Context) {
 	m.Post("/autoscaling/instance/deregister", binding.Json(halib.AutoScalingInstanceDeregisterRequest{}), model.AutoScalingInstanceDeregister)
 	m.Post("/autoscaling/config/update", binding.Json(halib.AutoScalingConfigUpdateRequest{}), model.AutoScalingConfigUpdate)
 	m.Get("/autoscaling", model.AutoScaling)
+	m.Get("/autoscaling/resolve/:alias", model.AutoScalingResolve)
 	m.Get("/metric/status", model.MetricDataBufferStatus)
 	m.Get("/status", model.Status)
 	m.Get("/status/memory", model.MemoryStatus)

--- a/command/resolve_alias.go
+++ b/command/resolve_alias.go
@@ -1,0 +1,40 @@
+package command
+
+import (
+	"fmt"
+
+	"io/ioutil"
+
+	"encoding/json"
+
+	"github.com/codegangsta/cli"
+	"github.com/heartbeatsjp/happo-agent/halib"
+	"github.com/heartbeatsjp/happo-agent/util"
+)
+
+//CmdResolveAlias implements subcommand `resolve_alias`
+func CmdResolveAlias(c *cli.Context) error {
+	if len(c.Args()) < 1 {
+		return cli.NewExitError("missing argument", 1)
+	}
+
+	alias := c.Args().First()
+	bastionEndpoint := c.String("bastion-endpoint")
+
+	res, err := util.RequestToAutoScalingResolveAPI(bastionEndpoint, alias)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	var autoScalingResolveResponce halib.AutoScalingResolveResponse
+	data, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	if err := json.Unmarshal(data, &autoScalingResolveResponce); err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	fmt.Println(autoScalingResolveResponce.IP)
+	return nil
+}

--- a/commands.go
+++ b/commands.go
@@ -274,6 +274,19 @@ var Commands = []cli.Command{
 			},
 		},
 	},
+	{
+		Name:   "resolve_alias",
+		Usage:  "Resolve alias.",
+		Action: command.CmdResolveAlias,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   "bastion-endpoint, b",
+				Value:  "https://127.0.0.1:6777",
+				Usage:  "Bastion (Nearby happo-agent) endpoint address",
+				EnvVar: "HAPPO_AGENT_BASTION_ENDPOINT",
+			},
+		},
+	},
 }
 
 // CommandNotFound implements action when subcommand not found

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -164,6 +164,12 @@ type AutoScalingResponse struct {
 	AutoScaling []AutoScalingData `json:"autoscaling"`
 }
 
+// AutoScalingResolveResponse is /autoscaling/resolve/:alias API
+type AutoScalingResolveResponse struct {
+	Status string `jspn:"status"`
+	IP     string `json:"ip"`
+}
+
 // AutoScalingRefreshResponse is /autoscaling/refresh API
 type AutoScalingRefreshResponse struct {
 	Status  string `json:"status"`

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/codegangsta/martini-contrib/render"
+	"github.com/go-martini/martini"
 	"github.com/heartbeatsjp/happo-agent/autoscaling"
 	"github.com/heartbeatsjp/happo-agent/halib"
 	"github.com/heartbeatsjp/happo-agent/util"
@@ -25,6 +26,28 @@ func AutoScaling(req *http.Request, r render.Render) {
 	}
 	autoScalingResponse.AutoScaling = autoScaling
 	r.JSON(http.StatusOK, autoScalingResponse)
+}
+
+// AutoScalingResolve return ip of alias
+func AutoScalingResolve(params martini.Params, r render.Render) {
+	var response halib.AutoScalingResolveResponse
+	alias := params["alias"]
+	if alias == "" {
+		response.Status = "error"
+		r.JSON(http.StatusBadRequest, response)
+		return
+	}
+
+	ip, err := autoscaling.AliasToIP(alias)
+	if err != nil {
+		response.Status = "error"
+		r.JSON(http.StatusInternalServerError, response)
+		return
+	}
+	response.Status = "OK"
+	response.IP = ip
+
+	r.JSON(http.StatusOK, response)
 }
 
 // AutoScalingConfigUpdate save autoscaling config

--- a/util/util.go
+++ b/util/util.go
@@ -183,3 +183,25 @@ func buildMetricAppendAPIRequest(endpoint string, postdata []byte) (*http.Client
 	}}
 	return client, req, err
 }
+
+// RequestToAutoScalingResolveAPI send request to AutoScalingResolveAPI
+func RequestToAutoScalingResolveAPI(endpoint string, alias string) (*http.Response, error) {
+	client, req, err := buildAutoScalingResolveAPIRequest(endpoint, alias)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+func buildAutoScalingResolveAPIRequest(endpoint string, alias string) (*http.Client, *http.Request, error) {
+	uri := fmt.Sprintf("%s/autoscaling/resolve/%s", endpoint, alias)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	return client, req, err
+}


### PR DESCRIPTION
I added `resolve_alias` subcommand in this PR.

This subcommand returns ip when alias specified in argument is already registered instance.

```
# happo-agent resolve_alias hb-autoscaling-web-1
172.16.4.131
```

In case alias specified in argument is not registered instance or alias not found, returns blank.

```
# happo-agent resolve_alias hb-autoscaling-web-3

```

@netmarkjp Please review.
