### PR TITLE
Change error handling behavior while metrics collection failed.

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -184,7 +184,7 @@ func CmdDaemon(c *cli.Context) {
 			if !disableCollectMetrics {
 				err := collect.Metrics(c.String("metric-config"))
 				if err != nil {
-					log.Fatal(err)
+					log.Error(err)
 				}
 			}
 		}


### PR DESCRIPTION
On error while metrics collection, `log.Fatal` (exit) is too sensitive.
I think just logging is enough.