### PR TITLE
Alias of auto scaling instances are changed to suffix is zero padding

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -381,7 +381,7 @@ func RefreshAutoScalingInstances(client *AWSClient, autoScalingGroupName, hostPr
 
 		for _, instance := range newInstances {
 			for i := 0; i < autoscalingCount; i++ {
-				key := fmt.Sprintf("ag-%s-%s-%d", autoScalingGroupName, hostPrefix, i+1)
+				key := fmt.Sprintf("ag-%s-%s-%02d", autoScalingGroupName, hostPrefix, i+1)
 				if _, ok := actualInstances[key]; !ok {
 					if _, ok := registeredInstances[key]; ok {
 						instance.MetricConfig = registeredInstances[key].MetricConfig
@@ -400,7 +400,7 @@ func RefreshAutoScalingInstances(client *AWSClient, autoScalingGroupName, hostPr
 			IP:           "",
 			MetricConfig: halib.MetricConfig{},
 		}
-		key := fmt.Sprintf("ag-%s-%s-%d", autoScalingGroupName, hostPrefix, i+1)
+		key := fmt.Sprintf("ag-%s-%s-%02d", autoScalingGroupName, hostPrefix, i+1)
 		if _, ok := actualInstances[key]; !ok {
 			if _, ok := registeredInstances[key]; ok {
 				emptyInstance.MetricConfig = registeredInstances[key].MetricConfig

--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -410,11 +410,6 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 					MetricConfig: halib.MetricConfig{},
 				},
 				{
-					InstanceID:   "i-jjjjjj",
-					IP:           "192.0.2.20",
-					MetricConfig: halib.MetricConfig{},
-				},
-				{
 					InstanceID:   "i-bbbbbb",
 					IP:           "192.0.2.12",
 					MetricConfig: halib.MetricConfig{},
@@ -454,6 +449,11 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 					IP:           "192.0.2.19",
 					MetricConfig: halib.MetricConfig{},
 				},
+				{
+					InstanceID:   "i-jjjjjj",
+					IP:           "192.0.2.20",
+					MetricConfig: halib.MetricConfig{},
+				},
 			},
 		},
 		{
@@ -465,11 +465,6 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 				{
 					InstanceID:   "i-aaaaaa",
 					IP:           "192.0.2.11",
-					MetricConfig: halib.MetricConfig{},
-				},
-				{
-					InstanceID:   "",
-					IP:           "",
 					MetricConfig: halib.MetricConfig{},
 				},
 				{
@@ -500,6 +495,11 @@ func TestRefreshAutoScalingInstances(t *testing.T) {
 				{
 					InstanceID:   "i-jjjjjj",
 					IP:           "192.0.2.20",
+					MetricConfig: halib.MetricConfig{},
+				},
+				{
+					InstanceID:   "",
+					IP:           "",
 					MetricConfig: halib.MetricConfig{},
 				},
 				{
@@ -717,8 +717,8 @@ func TestAliasToIP(t *testing.T) {
 		isNormalTest bool
 	}{
 		{
-			name:         "dummy-prod-ag-dummy-prod-app-1",
-			input:        "dummy-prod-ag-dummy-prod-app-1",
+			name:         "dummy-prod-ag-dummy-prod-app-01",
+			input:        "dummy-prod-ag-dummy-prod-app-01",
 			expected:     "192.0.2.11",
 			isNormalTest: true,
 		},


### PR DESCRIPTION
before:
- dummy-prod-ag-dummy-prod-app-1
- dummy-prod-ag-dummy-prod-app-2
- ...

after:
- dummy-prod-ag-dummy-prod-app-01
- dummy-prod-ag-dummy-prod-app-02
- ...

@netmarkjp 
Please review.
