### PR TITLE
http.Client and http.Transport override default and use

### DIFF
--- a/model/proxy.go
+++ b/model/proxy.go
@@ -33,6 +33,9 @@ var (
 )
 
 func init() {
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	_httpClient.Transport = tr
+
 	go func() {
 		for {
 			select {
@@ -129,8 +132,6 @@ func postToAgent(host string, port int, requestType string, jsonData []byte) (in
 	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(jsonData))
 	req.Header.Set("Content-Type", "application/json")
 
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	_httpClient.Transport = tr
 	resp, err := _httpClient.Do(req)
 	if err != nil {
 		if errTimeout, ok := err.(net.Error); ok && errTimeout.Timeout() {

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -24,10 +24,8 @@ import (
 // --- Global Variables
 var (
 	// See http://golang.org/pkg/net/http/#Client
-	tr = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	_httpClient = &http.Client{Transport: tr}
+	tr          = *http.DefaultTransport.(*http.Transport)
+	_httpClient = http.DefaultClient
 
 	refreshAutoScalingChan            = make(chan halib.AutoScalingConfigData)
 	refreshAutoScalingMutex           = sync.Mutex{}
@@ -132,6 +130,8 @@ func postToAgent(host string, port int, requestType string, jsonData []byte) (in
 	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(jsonData))
 	req.Header.Set("Content-Type", "application/json")
 
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	_httpClient.Transport = &tr
 	resp, err := _httpClient.Do(req)
 	if err != nil {
 		if errTimeout, ok := err.(net.Error); ok && errTimeout.Timeout() {

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -10,9 +10,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
-
 	"sync"
+	"time"
 
 	"github.com/codegangsta/martini-contrib/render"
 	"github.com/heartbeatsjp/happo-agent/autoscaling"

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -23,7 +23,7 @@ import (
 // --- Global Variables
 var (
 	// See http://golang.org/pkg/net/http/#Client
-	tr          = *http.DefaultTransport.(*http.Transport)
+	tr          = http.DefaultTransport.(*http.Transport)
 	_httpClient = http.DefaultClient
 
 	refreshAutoScalingChan            = make(chan halib.AutoScalingConfigData)
@@ -130,7 +130,7 @@ func postToAgent(host string, port int, requestType string, jsonData []byte) (in
 	req.Header.Set("Content-Type", "application/json")
 
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	_httpClient.Transport = &tr
+	_httpClient.Transport = tr
 	resp, err := _httpClient.Do(req)
 	if err != nil {
 		if errTimeout, ok := err.(net.Error); ok && errTimeout.Timeout() {


### PR DESCRIPTION
In proxy.go, `http.Client` and `http.Transport` are declared. However some parameters are not specified, allowing unexpected behave of http client.

ex) `IdleConnTimeout` is zero, it means HTTP Keep-Alive idle timeout is no limit

This PR fix it to use default settings and parameter override.