### PR TITLE
Fix proxy logging

### DIFF
--- a/model/proxy.go
+++ b/model/proxy.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -107,6 +108,12 @@ func Proxy(proxyRequest halib.ProxyRequest, r render.Render) (int, string) {
 
 func getAutoScalingInfo(nextHost string) halib.AutoScalingConfigData {
 	log := util.HappoAgentLogger()
+
+	if _, err := os.Stat(AutoScalingConfigFile); os.IsNotExist(err) {
+		log.Info(err)
+		return halib.AutoScalingConfigData{}
+	}
+
 	var autoScalingConfigData halib.AutoScalingConfigData
 	autoScalingList, err := autoscaling.GetAutoScalingConfig(AutoScalingConfigFile)
 	if err != nil {


### PR DESCRIPTION
In happo-agent 2.0.0, output error log when each requests to proxy when `autoscaing.yaml` not found.

```
2018-11-30 17:30:57 [error] failed to get autoscaling config: open /etc/happo-agent/autoscaling.yaml: no such file or directory
2018-11-30 17:30:59 [error] failed to get autoscaling config: open /etc/happo-agent/autoscaling.yaml: no such file or directory
2018-11-30 17:31:00 [error] failed to get autoscaling config: open /etc/happo-agent/autoscaling.yaml: no such file or directory
2018-11-30 17:31:00 [error] failed to get autoscaling config: open /etc/happo-agent/autoscaling.yaml: no such file or directory
```

I think it's unnecessary. Fixed it, if `autoscaling.yaml` is not exists, don't invoke `GetAutoScalingConfig()` but logging with INFO level.

@netmarkjp Please confirm.