### PR TITLE
Skip save metrics when metric config not found

### DIFF
--- a/collect/metrics.go
+++ b/collect/metrics.go
@@ -37,6 +37,10 @@ func Metrics(configPath string) error {
 		return err
 	}
 
+	if len(metricList.Metrics) < 1 {
+		return nil
+	}
+
 	metricTotalCount := 0
 	for _, metricHostList := range metricList.Metrics {
 		for _, metricPlugin := range metricHostList.Plugins {

--- a/collect/metrics_test.go
+++ b/collect/metrics_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 const TestConfigFile = "./metrics_test.yaml"
+const TestEmptyConfigFile = "./metrics_test_empty.yaml"
 const TestPlugin = "metrics_test_plugin"
 
 var ConfigData = halib.MetricConfig{
@@ -52,6 +53,13 @@ func TestGetCollectedMetrics1(t *testing.T) {
 
 	ret := GetCollectedMetrics()
 	assert.NotNil(t, ret)
+	assert.Nil(t, GetCollectedMetrics())
+}
+
+func TestGetCollectedMetrics2(t *testing.T) {
+	err := Metrics(TestEmptyConfigFile)
+	assert.Nil(t, err)
+
 	assert.Nil(t, GetCollectedMetrics())
 }
 

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -236,15 +236,15 @@ func CmdDaemon(c *cli.Context) {
 		}
 	}()
 
-	disableCollectMetrics := c.Bool("disable-collect-metrics")
-	util.HappoAgentLogger().Debug("disable-collect-metrics: ", disableCollectMetrics)
+	model.DisableCollectMetrics = c.Bool("disable-collect-metrics")
+	util.HappoAgentLogger().Debug("disable-collect-metrics: ", model.DisableCollectMetrics)
 
 	// Metric collect timer
 	timeMetrics := time.NewTicker(time.Minute).C
 	for {
 		select {
 		case <-timeMetrics:
-			if !disableCollectMetrics {
+			if !model.DisableCollectMetrics {
 				err := collect.Metrics(c.String("metric-config"))
 				if err != nil {
 					log.Error(err)

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -228,12 +228,13 @@ type AutoScalingLeaveResponse struct {
 
 // StatusResponse is /status API
 type StatusResponse struct {
-	AppVersion         string            `json:"app_version"`
-	UptimeSeconds      int64             `json:"uptime_seconds"`
-	NumGoroutine       int               `json:"num_goroutine"`
-	MetricBufferStatus map[string]int64  `json:"metric_buffer_status"`
-	Callers            []string          `json:"callers"`
-	LevelDBProperties  map[string]string `json:"leveldb_properties"`
+	AppVersion            string            `json:"app_version"`
+	UptimeSeconds         int64             `json:"uptime_seconds"`
+	DisableCollectMetrics bool              `json:"disable_collect_metrics"`
+	NumGoroutine          int               `json:"num_goroutine"`
+	MetricBufferStatus    map[string]int64  `json:"metric_buffer_status"`
+	Callers               []string          `json:"callers"`
+	LevelDBProperties     map[string]string `json:"leveldb_properties"`
 }
 
 // RequestStatusResponse is /status/request API

--- a/model/status.go
+++ b/model/status.go
@@ -18,6 +18,8 @@ import (
 var (
 	// AppVersion equals main.Version
 	AppVersion string
+	// DisableCollectMetrics included to /status response
+	DisableCollectMetrics bool
 
 	startAt = time.Now()
 )
@@ -64,12 +66,13 @@ func Status(req *http.Request, r render.Render) {
 	log.Debugf("leveldbProperties:%v", leveldbProperties)
 
 	statusResponse := &halib.StatusResponse{
-		AppVersion:         AppVersion,
-		UptimeSeconds:      int64(time.Since(startAt) / time.Second),
-		NumGoroutine:       runtime.NumGoroutine(),
-		MetricBufferStatus: collect.GetMetricDataBufferStatus(false),
-		Callers:            callers,
-		LevelDBProperties:  leveldbProperties,
+		AppVersion:            AppVersion,
+		UptimeSeconds:         int64(time.Since(startAt) / time.Second),
+		DisableCollectMetrics: DisableCollectMetrics,
+		NumGoroutine:          runtime.NumGoroutine(),
+		MetricBufferStatus:    collect.GetMetricDataBufferStatus(false),
+		Callers:               callers,
+		LevelDBProperties:     leveldbProperties,
 	}
 	r.JSON(http.StatusOK, statusResponse)
 }


### PR DESCRIPTION
I fixed an issue that happo-agent saves an empty metric data when metric config not found.

@netmarkjp  
Please review.
