### PR TITLE
Add /autoscaling/health API

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,25 @@ wget -q --no-check-certificate -O -  https://127.0.0.1:6777/autoscaling/leave --
 {"status":"OK","message":""}
 ```
 
+### /autoscaling/health/:alias
+
+- Input format
+    - None
+- Input variables
+    - None
+- Return format
+    - JSON
+- Return variables
+    - status: result status
+    - message: message from agent (if error occurred)
+    - ip: private ip address by Amazon EC2
+
+```
+# wget -q --no-check-certificate -O -  https://127.0.0.1:6777/autoscaling/health/hb-autoscaling-app-1
+{"Status":"OK","message":"",ip:"192.0.2.1"}
+```
+
+
 ### /status
 
 Get happo-agent status

--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -3,24 +3,21 @@ package autoscaling
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-agent/halib"
 	"github.com/heartbeatsjp/happo-agent/util"
+	"github.com/pkg/errors"
 	"github.com/syndtr/goleveldb/leveldb"
 	leveldbUtil "github.com/syndtr/goleveldb/leveldb/util"
-
-	"encoding/json"
-
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // AutoScaling list autoscaling instances

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -205,6 +205,7 @@ func CmdDaemon(c *cli.Context) {
 	}
 	m.Get("/autoscaling", model.AutoScaling)
 	m.Get("/autoscaling/resolve/:alias", model.AutoScalingResolve)
+	m.Get("/autoscaling/health/:alias", model.AutoScalingHealth)
 	m.Get("/metric/status", model.MetricDataBufferStatus)
 	m.Get("/status", model.Status)
 	m.Get("/status/memory", model.MemoryStatus)

--- a/halib/struct.go
+++ b/halib/struct.go
@@ -226,6 +226,13 @@ type AutoScalingLeaveResponse struct {
 	Message string `json:"message"`
 }
 
+// AutoScalingHealthResponse is /autoscaling/health/:alias API
+type AutoScalingHealthResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	IP      string `json:"ip"`
+}
+
 // StatusResponse is /status API
 type StatusResponse struct {
 	AppVersion            string            `json:"app_version"`

--- a/model/autoscaling_test.go
+++ b/model/autoscaling_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestAutoScalingHealth(t *testing.T) {
-
 	setup()
 	defer teardown()
 

--- a/model/autoscaling_test.go
+++ b/model/autoscaling_test.go
@@ -1,0 +1,88 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/codegangsta/martini-contrib/render"
+	"github.com/go-martini/martini"
+	"github.com/heartbeatsjp/happo-agent/halib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAutoScalingHealth(t *testing.T) {
+
+	setup()
+	defer teardown()
+
+	//bastion
+	m := martini.Classic()
+	m.Use(render.Renderer())
+	m.Get("/autoscaling/health/:alias", AutoScalingHealth)
+
+	//edge
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, "OK")
+			}))
+	defer ts.Close()
+
+	re, _ := regexp.Compile("([a-z]+)://([A-Za-z0-9.]+):([0-9]+)(.*)")
+	found := re.FindStringSubmatch(ts.URL)
+	port, _ := strconv.Atoi(found[3])
+
+	urlPrefix := "/autoscaling/health"
+	var cases = []struct {
+		url  string
+		want string
+	}{
+		{
+			url:  fmt.Sprintf("%s/dummy-prod-ag-dummy-prod-app-1?port=%d", urlPrefix, port),
+			want: "OK",
+		},
+		{
+			url:  fmt.Sprintf("%s/dummy-prod-ag-dummy-prod-app-2", urlPrefix),
+			want: "OK",
+		},
+		{
+			url:  fmt.Sprintf("%s/dummy-prod-ag-dummy-prod-app-1?port=9999", urlPrefix),
+			want: "error",
+		},
+		{
+			url:  fmt.Sprintf("%s/dummy-prod-ag-dummy-prod-app-1?port=test", urlPrefix),
+			want: "error",
+		},
+		{
+			url:  fmt.Sprintf("%s/missing-ag-app-1", urlPrefix),
+			want: "error",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.url, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", c.url, nil)
+			res := httptest.NewRecorder()
+
+			m.ServeHTTP(res, req)
+
+			data, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var r halib.AutoScalingHealthResponse
+			if err := json.Unmarshal(data, &r); err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, c.want, r.Status)
+		})
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -203,6 +204,31 @@ func buildMetricAppendAPIRequest(endpoint string, postdata []byte) (*http.Client
 	req.Header.Set("Content-Type", "application/json")
 
 	//FIXME other parameters should be proper values
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	return client, req, err
+}
+
+// RequestToCheckAvailableAPI send request to AutoScalingHealthAPI
+func RequestToCheckAvailableAPI(endpoint string) (*http.Response, error) {
+	client, req, err := buildCheckAvailableAPIRequest(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(req)
+}
+
+func buildCheckAvailableAPIRequest(endpoint string) (*http.Client, *http.Request, error) {
+	uri := fmt.Sprintf("%s/", endpoint)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	req = req.WithContext(ctx)
+
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}

--- a/util/util.go
+++ b/util/util.go
@@ -212,27 +212,22 @@ func buildMetricAppendAPIRequest(endpoint string, postdata []byte) (*http.Client
 
 // RequestToCheckAvailableAPI send request to AutoScalingHealthAPI
 func RequestToCheckAvailableAPI(endpoint string) (*http.Response, error) {
-	client, req, err := buildCheckAvailableAPIRequest(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	return client.Do(req)
-}
-
-func buildCheckAvailableAPIRequest(endpoint string) (*http.Client, *http.Request, error) {
 	uri := fmt.Sprintf("%s/", endpoint)
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	req = req.WithContext(ctx)
 
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}
-	return client, req, err
+
+	return client.Do(req)
 }
 
 // RequestToAutoScalingResolveAPI send request to AutoScalingResolveAPI


### PR DESCRIPTION
I added `/autoscaling/health` API that can checks auto scaling node is available.

This API works on the bastion. A bastion's happo-agent receives a request in `/autoscaling/health/:alias`,  resolves the alias to IP address, after that send a request to `/` on that IP address.