### PR TITLE
Fix out of sync in this project

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,17 +2,22 @@
 
 
 [[projects]]
+  digest = "1:8cf46b6c18a91068d446e26b67512cf16f1540b45d90b28b9533706a127f0ca6"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:610009a24997eeaa5b1d88b68958ac7d92c983b4b0a07239f58d438253cf3c29"
   name = "github.com/Songmu/timeout"
   packages = ["."]
+  pruneopts = ""
   revision = "84831c43cf48f6b1d52c64ed499d714ffd62eca1"
 
 [[projects]]
+  digest = "1:6e310435eaadcbbdd1e3dbc52c2ec4adc319948bd66b86b7ee68e9270b9bdc55"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -36,6 +41,8 @@
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
@@ -44,87 +51,124 @@
     "service/autoscaling/autoscalingiface",
     "service/ec2",
     "service/ec2/ec2iface",
-    "service/sts"
+    "service/ssm",
+    "service/ssm/ssmiface",
+    "service/sts",
   ]
+  pruneopts = ""
   revision = "236a3fce423171d03ae327a8aa2512e6fb24df36"
   version = "v1.13.39"
 
 [[projects]]
+  digest = "1:fdc0c20c9c6ec3bf4a5b9d5ee2ed2ddf6fe61c26d8c8b3dfe52c22064430c2d4"
   name = "github.com/client9/reopen"
   packages = ["."]
+  pruneopts = ""
   revision = "4b86f9c0ead51cc410d05655596e30f281ed9071"
 
 [[projects]]
+  digest = "1:58b484c6ec08df874223d884af3028b3bf0d3606bd44c60d533e161e22dbb7bd"
   name = "github.com/codegangsta/cli"
   packages = ["."]
+  pruneopts = ""
   revision = "a14d7d367bc02b1f57d88de97926727f2d936387"
   version = "v1.18.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:c18e048e3b34e24e77d5e99c0b2cc4f346ffb0b2d02f6fea16b64cfc59252354"
   name = "github.com/codegangsta/inject"
   packages = ["."]
+  pruneopts = ""
   revision = "33e0aa1cb7c019ccc3fbe049a8262a6403d30504"
 
 [[projects]]
+  digest = "1:ac88e87ba3792599ea60b827572d897909a1ce1ab0ecf42644eac366bfb00429"
   name = "github.com/codegangsta/martini"
   packages = ["."]
+  pruneopts = ""
   revision = "fe605b5cd210047ae3bb73d2b69a5b912a9b423d"
 
 [[projects]]
+  digest = "1:89a23f9bbb20c63fffa02ba58848d282a4a1b6931ec6731e623cccb3fc7f1015"
   name = "github.com/codegangsta/martini-contrib"
   packages = [
     "render",
-    "secure"
+    "secure",
   ]
+  pruneopts = ""
   revision = "8ce6181c2609699e4c7cd30994b76a850a9cdadc"
 
 [[projects]]
+  digest = "1:3344ca3a831a54d5e38be264846ce18c77a8e4949a86b7b06d21cbdab75c2ada"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "2df174808ee097f90d259e432cc04442cf60be21"
 
 [[projects]]
+  digest = "1:f6d8770900622a855dbeda0aaefb536ad97bc30315e6647a02c4e2044f4a858f"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = ""
   revision = "6529cf7c58879c08d927016dde4477f18a0634cb"
   version = "v1.36.0"
 
 [[projects]]
+  digest = "1:7782dbd9103e57f5c100340040ea8a8f6cc374f21b8e631183e4ea907b21c63d"
   name = "github.com/go-martini/martini"
   packages = ["."]
+  pruneopts = ""
   revision = "49411a5b646861ad29a6ddd5351717a0a9c49b94"
   version = "v1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:09307dfb1aa3f49a2bf869dcfa4c6c06ecd3c207221bd1c1a1141f0e51f209eb"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = ""
   revision = "553a641470496b2327abcac10b36396bd98e45c9"
 
 [[projects]]
+  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "0b12d6b5"
 
 [[projects]]
-  branch = "master"
+  digest = "1:4e8f5aceaf30f8f73a003aee32d06e353e57240d97302ceb0cdeebcc4f3eabf2"
   name = "github.com/martini-contrib/binding"
   packages = ["."]
+  pruneopts = ""
   revision = "05d3e151b6cf34dacac6306226a33db68459a3b5"
 
 [[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
+  digest = "1:31ba63a60f9e41b5cbb6cce48f4756718bd514fe73a1c6ee2751ec8fbf6e109f"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 
 [[projects]]
+  digest = "1:a13cb503c52c7f571ba5bae6361aa95f1d11abd1756fcd0945f5d69c06d9162b"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = ""
   revision = "f390dcf405f7b83c997eac1b06768bb9f44dec18"
   version = "v1.1.3"
 
 [[projects]]
+  digest = "1:df1df2b80cebaaec501c11ebdabfc64e690347448b8bc152311951b161c87d88"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -138,35 +182,73 @@
     "leveldb/opt",
     "leveldb/storage",
     "leveldb/table",
-    "leveldb/util"
+    "leveldb/util",
   ]
+  pruneopts = ""
   revision = "8c81ea47d4c41a385645e133e15510fc6a2a74b4"
 
 [[projects]]
   branch = "master"
+  digest = "1:6ef14be530be39b6b9d75d54ce1d546ae9231e652d9e3eef198cbb19ce8ed3e7"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [[projects]]
+  digest = "1:e2bfa51b5f544223085b23680f804a73fe7a125d32f031a34c22de8567be4a80"
   name = "golang.org/x/net"
   packages = ["netutil"]
+  pruneopts = ""
   revision = "9313baa13d9262e49d07b20ed57dceafcd7240cc"
 
 [[projects]]
   branch = "master"
+  digest = "1:26efb515a562ba2f386e4a4cc3067cd5e131353672abc1a3ff28e22cc83232d5"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
   revision = "151529c776cdc58ddbe7963ba9af779f3577b419"
 
 [[projects]]
+  digest = "1:59925e8b791ee90b60e4dc05099d34fd38d0922a2a8f9b4e700cb61fc421e6b2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "e4d366fc3c7938e2958e662b4258c7a89e1f0e3e"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "713f3a3dee76ecaf88febcd244efe97f064c07c7a5b92cb4da9e81279ce99a52"
+  input-imports = [
+    "github.com/Sirupsen/logrus",
+    "github.com/Songmu/timeout",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/ec2metadata",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/autoscaling",
+    "github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface",
+    "github.com/aws/aws-sdk-go/service/ec2",
+    "github.com/aws/aws-sdk-go/service/ec2/ec2iface",
+    "github.com/aws/aws-sdk-go/service/ssm",
+    "github.com/aws/aws-sdk-go/service/ssm/ssmiface",
+    "github.com/client9/reopen",
+    "github.com/codegangsta/cli",
+    "github.com/codegangsta/martini-contrib/render",
+    "github.com/codegangsta/martini-contrib/secure",
+    "github.com/go-martini/martini",
+    "github.com/martini-contrib/binding",
+    "github.com/pkg/errors",
+    "github.com/stretchr/testify/assert",
+    "github.com/syndtr/goleveldb/leveldb",
+    "github.com/syndtr/goleveldb/leveldb/errors",
+    "github.com/syndtr/goleveldb/leveldb/storage",
+    "github.com/syndtr/goleveldb/leveldb/util",
+    "golang.org/x/net/netutil",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,3 +67,7 @@
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
   version = "1.13.39"
+
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "v0.8.1"


### PR DESCRIPTION
I fixed an issue that out of sync in this project.

```
$ dep status
Gopkg.lock is out of sync with imports and/or Gopkg.toml. Run `dep check` for details.
PROJECT                MISSING PACKAGES
github.com/pkg/errors  [github.com/pkg/errors]
input-digest mismatch
```

I run `dep ensure` to install above missing packages.
After that, I added new rules for "github.com/pkg/errors" in Gopkg.toml.

I run `dep ensure` again, and confirmed no change for Gopkg.lock.

NOTE:  My local environment dep version is v0.5.0.

```
$ dep version
dep:
 version     : v0.5.0
 build date  : 2018-07-26
 git hash    : 224a564
 go version  : go1.10.3
 go compiler : gc
 platform    : darwin/amd64
 features    : ImportDuringSolve=false
```
