### PR TITLE
`list_aliases` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ Subcommand for [API client mode](#api-client-mode)
 /path/to/happo-agent leave -n [NODE_ENDPOINT_URL]
 ```
 
+#### List aliases
+
+```
+/path/to/happo-agent list_aliases -b [BASTION_ENDPOINT_URL] -n [AUTOSCALING_GROUP_NAME] -all
+```
+
+
 ### Setting for bastion
 
 ```bash

--- a/command/list_aliases.go
+++ b/command/list_aliases.go
@@ -4,47 +4,61 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/heartbeatsjp/happo-agent/halib"
 	"github.com/heartbeatsjp/happo-agent/util"
+	"github.com/pkg/errors"
 )
 
 // CmdListAliases list aliases
 func CmdListAliases(c *cli.Context) error {
 	bastionEndpoint := c.String("bastion-endpoint")
+	agName := c.String("autoscaling_group_name")
+	listAll := c.Bool("all")
 
-	res, err := util.RequestToAutoScalingAPI(bastionEndpoint)
+	out, err := listAliases(bastionEndpoint, agName, listAll)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
+	}
+
+	fmt.Println(out)
+
+	return nil
+}
+
+func listAliases(bastionEndpoint, agName string, listAll bool) (string, error) {
+	res, err := util.RequestToAutoScalingAPI(bastionEndpoint)
+	if err != nil {
+		return "", err
 	}
 
 	var autoScalingResponse halib.AutoScalingResponse
 	data, err := ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
-		return cli.NewExitError(err.Error(), 1)
+		return "", err
 	}
 	if err := json.Unmarshal(data, &autoScalingResponse); err != nil {
-		return cli.NewExitError(err.Error(), 1)
+		return "", err
 	}
 
 	if len(autoScalingResponse.AutoScaling) < 1 {
-		cli.NewExitError("Missing auto scaling group", 1)
+		return "", errors.New("Missing auto scaling group")
 	}
 
-	agName := c.String("autoscaling_group_name")
-	listAll := c.Bool("all")
-
+	var out string
 	for _, a := range autoScalingResponse.AutoScaling {
 		if agName == "" || agName == a.AutoScalingGroupName {
 			for _, i := range a.Instances {
 				if listAll || i.InstanceData.IP != "" {
-					fmt.Println(i.Alias + "," + i.InstanceData.IP + "," + i.InstanceData.InstanceID)
+					out = out + fmt.Sprintln(i.Alias+","+i.InstanceData.IP+","+i.InstanceData.InstanceID)
 				}
 			}
 		}
 	}
+	out = strings.TrimSuffix(out, "\n")
 
-	return nil
+	return out, nil
 }

--- a/command/list_aliases.go
+++ b/command/list_aliases.go
@@ -53,7 +53,7 @@ func listAliases(bastionEndpoint, agName string, listAll bool) (string, error) {
 		if agName == "" || agName == a.AutoScalingGroupName {
 			for _, i := range a.Instances {
 				if listAll || i.InstanceData.IP != "" {
-					out = out + fmt.Sprintln(i.Alias+","+i.InstanceData.IP+","+i.InstanceData.InstanceID)
+					out = out + strings.Join([]string{i.Alias, i.InstanceData.IP, i.InstanceData.InstanceID}, ",") + "\n"
 				}
 			}
 		}

--- a/command/list_aliases.go
+++ b/command/list_aliases.go
@@ -1,0 +1,50 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/codegangsta/cli"
+	"github.com/heartbeatsjp/happo-agent/halib"
+	"github.com/heartbeatsjp/happo-agent/util"
+)
+
+// CmdListAliases list aliases
+func CmdListAliases(c *cli.Context) error {
+	bastionEndpoint := c.String("bastion-endpoint")
+
+	res, err := util.RequestToAutoScalingAPI(bastionEndpoint)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	var autoScalingResponse halib.AutoScalingResponse
+	data, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	if err := json.Unmarshal(data, &autoScalingResponse); err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	if len(autoScalingResponse.AutoScaling) < 1 {
+		cli.NewExitError("Missing auto scaling group", 1)
+	}
+
+	agName := c.String("autoscaling_group_name")
+	listAll := c.Bool("all")
+
+	for _, a := range autoScalingResponse.AutoScaling {
+		if agName == "" || agName == a.AutoScalingGroupName {
+			for _, i := range a.Instances {
+				if listAll || i.InstanceData.IP != "" {
+					fmt.Println(i.Alias + "," + i.InstanceData.IP + "," + i.InstanceData.InstanceID)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/command/list_aliases.go
+++ b/command/list_aliases.go
@@ -48,17 +48,16 @@ func listAliases(bastionEndpoint, agName string, listAll bool) (string, error) {
 		return "", errors.New("Missing auto scaling group")
 	}
 
-	var out string
+	var outs []string
 	for _, a := range autoScalingResponse.AutoScaling {
 		if agName == "" || agName == a.AutoScalingGroupName {
 			for _, i := range a.Instances {
 				if listAll || i.InstanceData.IP != "" {
-					out = out + strings.Join([]string{i.Alias, i.InstanceData.IP, i.InstanceData.InstanceID}, ",") + "\n"
+					outs = append(outs, strings.Join([]string{i.Alias, i.InstanceData.IP, i.InstanceData.InstanceID}, ","))
 				}
 			}
 		}
 	}
-	out = strings.TrimSuffix(out, "\n")
 
-	return out, nil
+	return strings.Join(outs, "\n"), nil
 }

--- a/command/list_aliases_test.go
+++ b/command/list_aliases_test.go
@@ -1,0 +1,183 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/heartbeatsjp/happo-agent/halib"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_listAliases(t *testing.T) {
+	var res halib.AutoScalingResponse
+	res.AutoScaling = []halib.AutoScalingData{
+		{
+			AutoScalingGroupName: "dummy-prod-ag",
+			Instances: []struct {
+				Alias        string             `json:"alias"`
+				InstanceData halib.InstanceData `json:"instance_data"`
+			}{
+				{
+					Alias: "dummy-prod-ag-web-01",
+					InstanceData: halib.InstanceData{
+						InstanceID: "i-0123456789abcded1",
+						IP:         "192.0.2.1",
+					},
+				},
+				{
+					Alias: "dummy-prod-ag-web-02",
+					InstanceData: halib.InstanceData{
+						InstanceID: "i-0123456789abcded2",
+						IP:         "192.0.2.2",
+					},
+				},
+				{
+					Alias: "dummy-prod-ag-web-03",
+					InstanceData: halib.InstanceData{
+						InstanceID: "",
+						IP:         "",
+					},
+				},
+				{
+					Alias: "dummy-prod-ag-web-04",
+					InstanceData: halib.InstanceData{
+						InstanceID: "",
+						IP:         "",
+					},
+				},
+			},
+		},
+		{
+			AutoScalingGroupName: "dummy-stg-ag",
+			Instances: []struct {
+				Alias        string             `json:"alias"`
+				InstanceData halib.InstanceData `json:"instance_data"`
+			}{
+				{
+					Alias: "dummy-stg-ag-web-01",
+					InstanceData: halib.InstanceData{
+						InstanceID: "i-1123456789abcded1",
+						IP:         "192.0.2.11",
+					},
+				},
+				{
+					Alias: "dummy-stg-ag-web-02",
+					InstanceData: halib.InstanceData{
+						InstanceID: "i-1123456789abcded2",
+						IP:         "192.0.2.12",
+					},
+				},
+			},
+		},
+	}
+
+	b, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, string(b))
+			}))
+	defer ts.Close()
+
+	type args struct {
+		bastionEndpoint string
+		agName          string
+		listAll         bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "",
+			args: args{
+				bastionEndpoint: ts.URL,
+				agName:          "",
+				listAll:         false,
+			},
+			want: `dummy-prod-ag-web-01,192.0.2.1,i-0123456789abcded1
+dummy-prod-ag-web-02,192.0.2.2,i-0123456789abcded2
+dummy-stg-ag-web-01,192.0.2.11,i-1123456789abcded1
+dummy-stg-ag-web-02,192.0.2.12,i-1123456789abcded2`,
+			wantErr: false,
+		},
+		{
+			name: "",
+			args: args{
+				bastionEndpoint: ts.URL,
+				agName:          "dummy-prod-ag",
+				listAll:         false,
+			},
+			want: `dummy-prod-ag-web-01,192.0.2.1,i-0123456789abcded1
+dummy-prod-ag-web-02,192.0.2.2,i-0123456789abcded2`,
+			wantErr: false,
+		},
+		{
+			name: "",
+			args: args{
+				bastionEndpoint: ts.URL,
+				agName:          "",
+				listAll:         true,
+			},
+			want: `dummy-prod-ag-web-01,192.0.2.1,i-0123456789abcded1
+dummy-prod-ag-web-02,192.0.2.2,i-0123456789abcded2
+dummy-prod-ag-web-03,,
+dummy-prod-ag-web-04,,
+dummy-stg-ag-web-01,192.0.2.11,i-1123456789abcded1
+dummy-stg-ag-web-02,192.0.2.12,i-1123456789abcded2`,
+			wantErr: false,
+		},
+		{
+			name: "",
+			args: args{
+				bastionEndpoint: ts.URL,
+				agName:          "missing-ag",
+				listAll:         false,
+			},
+			want:    "",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := listAliases(tt.args.bastionEndpoint, tt.args.agName, tt.args.listAll)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func Test_listAlias_emptyResponse(t *testing.T) {
+	var res halib.AutoScalingResponse
+	res.AutoScaling = []halib.AutoScalingData{}
+
+	b, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, string(b))
+			}))
+	defer ts.Close()
+
+	got, err := listAliases(ts.URL, "", false)
+	assert.Equal(t, got, "")
+	assert.NotNil(t, err)
+}

--- a/commands.go
+++ b/commands.go
@@ -375,8 +375,9 @@ var Commands = []cli.Command{
 				EnvVar: "HAPPO_AGENT_AUTOSCALING_GROUP_NAME",
 			},
 			cli.BoolFlag{
-				Name:  "all",
-				Usage: "List all aliases that contain alias not attached EC2 instance",
+				Name:   "all",
+				Usage:  "List all aliases that contain alias not attached EC2 instance",
+				EnvVar: "HAPPO_AGENT_AUTOSCALING_LIST_ALIASES_ALL",
 			},
 		},
 	},

--- a/commands.go
+++ b/commands.go
@@ -376,7 +376,7 @@ var Commands = []cli.Command{
 			},
 			cli.BoolFlag{
 				Name:  "all",
-				Usage: "",
+				Usage: "List all aliases that contain alias not attached EC2 instance",
 			},
 		},
 	},

--- a/commands.go
+++ b/commands.go
@@ -359,6 +359,28 @@ var Commands = []cli.Command{
 		},
 	},
 	{
+		Name:   "list_aliases",
+		Usage:  "List aliases.",
+		Action: command.CmdListAliases,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   "bastion-endpoint, b",
+				Value:  "https://127.0.0.1:6777",
+				Usage:  "Bastion (Nearby happo-agent) endpoint address",
+				EnvVar: "HAPPO_AGENT_BASTION_ENDPOINT",
+			},
+			cli.StringFlag{
+				Name:   "autoscaling_group_name, n",
+				Usage:  "Auto Scaling Group Name",
+				EnvVar: "HAPPO_AGENT_AUTOSCALING_GROUP_NAME",
+			},
+			cli.BoolFlag{
+				Name:  "all",
+				Usage: "",
+			},
+		},
+	},
+	{
 		Name:   "leave",
 		Usage:  "Leave from autoscaling.",
 		Action: command.CmdLeave,

--- a/util/util.go
+++ b/util/util.go
@@ -210,6 +210,21 @@ func buildMetricAppendAPIRequest(endpoint string, postdata []byte) (*http.Client
 	return client, req, err
 }
 
+// RequestToAutoScalingAPI send request to AutoScalingHealthAPI
+func RequestToAutoScalingAPI(endpoint string) (*http.Response, error) {
+	uri := fmt.Sprintf("%s/autoscaling", endpoint)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	return client.Do(req)
+}
+
 // RequestToCheckAvailableAPI send request to AutoScalingHealthAPI
 func RequestToCheckAvailableAPI(endpoint string) (*http.Response, error) {
 	uri := fmt.Sprintf("%s/", endpoint)

--- a/util/util.go
+++ b/util/util.go
@@ -210,7 +210,7 @@ func buildMetricAppendAPIRequest(endpoint string, postdata []byte) (*http.Client
 	return client, req, err
 }
 
-// RequestToAutoScalingAPI send request to AutoScalingHealthAPI
+// RequestToAutoScalingAPI send request to AutoScalingAPI
 func RequestToAutoScalingAPI(endpoint string) (*http.Response, error) {
 	uri := fmt.Sprintf("%s/autoscaling", endpoint)
 	req, err := http.NewRequest("GET", uri, nil)


### PR DESCRIPTION
I added subcommand named `list_aliases` that is a more human-readable interface compare with `/autoscaling` API.

```
$ happo-agent list_aliases
hb-autoscaling-web-01,192.0.2.1,i-0123456789abcdef0
hb-autoscaling-web-02,192.0.2.1,i-0123456789abcdef1
```

```
$ happo-agent list_aliases -all
hb-autoscaling-web-01,192.0.2.1,i-0123456789abcdef0
hb-autoscaling-web-02,192.0.2.1,i-0123456789abcdef1
hb-autoscaling-web-03,,
hb-autoscaling-web-04,,
```

This subcommand is useful when an operator logins server, in case an occurred incident affects the Auto Scaling Group.
