### PR TITLE
Fix AWS client

### DIFF
--- a/autoscaling/aws.go
+++ b/autoscaling/aws.go
@@ -17,6 +17,7 @@ import (
 	"github.com/heartbeatsjp/happo-agent/halib"
 )
 
+// ErrNotRunningEC2 represents error for not running within Amazon EC2 when daemon mode
 var ErrNotRunningEC2 = errors.New("not running within Amazon EC2")
 
 // AWSClient allows you to get the list of IP addresses of instanes of an Auto Scaling group

--- a/autoscaling/aws.go
+++ b/autoscaling/aws.go
@@ -26,7 +26,8 @@ type AWSClient struct {
 	SvcAutoscaling autoscalingiface.AutoScalingAPI
 }
 
-// NewAWSClient return AWSClient
+// NewAWSClient returns AWSClient when running within Amazon EC2.
+// If running in not Amazon EC2, returns ErrNotRunningEC2 as an error.
 func NewAWSClient() (*AWSClient, error) {
 	sess := session.Must(session.NewSession())
 	ec2Meta := ec2metadata.New(session.Must(session.NewSession()))
@@ -57,7 +58,8 @@ type NodeAWSClient struct {
 	SvcEC2Metadata EC2MetadataAPI
 }
 
-// NewNodeAWSClient return NodeAWSClient
+// NewNodeAWSClient returns NodeAWSClient when running within Amazon EC2.
+// If running in not Amazon EC2, returns ErrNotRunningEC2 as an error.
 func NewNodeAWSClient() (*NodeAWSClient, error) {
 	sess := session.Must(session.NewSession())
 	ec2Meta := ec2metadata.New(session.Must(session.NewSession()))

--- a/autoscaling/aws.go
+++ b/autoscaling/aws.go
@@ -17,6 +17,8 @@ import (
 	"github.com/heartbeatsjp/happo-agent/halib"
 )
 
+var ErrNotRunningEC2 = errors.New("not running within Amazon EC2")
+
 // AWSClient allows you to get the list of IP addresses of instanes of an Auto Scaling group
 type AWSClient struct {
 	SvcEC2         ec2iface.EC2API
@@ -27,6 +29,10 @@ type AWSClient struct {
 func NewAWSClient() (*AWSClient, error) {
 	sess := session.Must(session.NewSession())
 	ec2Meta := ec2metadata.New(session.Must(session.NewSession()))
+	if !ec2Meta.Available() {
+		return nil, ErrNotRunningEC2
+	}
+
 	region, err := ec2Meta.Region()
 	if err != nil {
 		return nil, err
@@ -54,6 +60,10 @@ type NodeAWSClient struct {
 func NewNodeAWSClient() (*NodeAWSClient, error) {
 	sess := session.Must(session.NewSession())
 	ec2Meta := ec2metadata.New(session.Must(session.NewSession()))
+	if !ec2Meta.Available() {
+		return nil, ErrNotRunningEC2
+	}
+
 	region, err := ec2Meta.Region()
 	if err != nil {
 		return nil, err

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -132,7 +132,9 @@ func CmdDaemon(c *cli.Context) {
 		nodeClient, err := autoscaling.NewNodeAWSClient()
 		if err == nil {
 			m.Map(nodeClient)
-		} else if err != autoscaling.ErrNotRunningEC2 {
+		} else if err == autoscaling.ErrNotRunningEC2 {
+			log.Error("create aws client failed: ", err)
+		} else {
 			log.Fatal("create aws client failed: ", err)
 		}
 
@@ -194,7 +196,9 @@ func CmdDaemon(c *cli.Context) {
 		client, err := autoscaling.NewAWSClient()
 		if err == nil {
 			m.Map(client)
-		} else if err != autoscaling.ErrNotRunningEC2 {
+		} else if err == autoscaling.ErrNotRunningEC2 {
+			log.Error("create aws client failed: ", err)
+		} else {
 			log.Fatal("create aws client failed: ", err)
 		}
 	}

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -201,7 +201,7 @@ func AutoScalingDelete(request halib.AutoScalingDeleteRequest, r render.Render) 
 }
 
 // AutoScalingRefresh refresh autoscaling
-func AutoScalingRefresh(request halib.AutoScalingRefreshRequest, r render.Render) {
+func AutoScalingRefresh(request halib.AutoScalingRefreshRequest, r render.Render, client *autoscaling.AWSClient) {
 	var response halib.AutoScalingRefreshResponse
 
 	autoScalingList, err := autoscaling.GetAutoScalingConfig(AutoScalingConfigFile)
@@ -240,7 +240,6 @@ func AutoScalingRefresh(request halib.AutoScalingRefreshRequest, r render.Render
 		return
 	}
 
-	client := autoscaling.NewAWSClient()
 	var errors []string
 	for _, a := range refreshAutoScalingGroups {
 		err = autoscaling.RefreshAutoScalingInstances(client, a.autoScalingGroupName, a.hostPrefix, a.autoScalingCount)
@@ -261,10 +260,9 @@ func AutoScalingRefresh(request halib.AutoScalingRefreshRequest, r render.Render
 
 // AutoScalingLeave deregister self node from autoscaling bastion.
 // this handler is available only in agent running with autoscaling node.
-func AutoScalingLeave(request halib.AutoScalingLeaveRequest, r render.Render) {
+func AutoScalingLeave(request halib.AutoScalingLeaveRequest, r render.Render, client *autoscaling.NodeAWSClient) {
 	var response halib.AutoScalingLeaveResponse
 
-	client := autoscaling.NewNodeAWSClient()
 	if err := autoscaling.LeaveAutoScalingGroup(client, AutoScalingBastionEndpoint); err != nil {
 		response.Status = "error"
 		response.Message = fmt.Sprintf("failed to leave: %s", err.Error())

--- a/model/proxy_test.go
+++ b/model/proxy_test.go
@@ -2,23 +2,21 @@ package model
 
 import (
 	"bytes"
+	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"regexp"
 	"strconv"
 	"testing"
 	"time"
 
-	"os"
-
-	"encoding/gob"
-
-	"encoding/json"
-
 	"github.com/codegangsta/martini-contrib/render"
 	"github.com/go-martini/martini"
+	"github.com/heartbeatsjp/happo-agent/autoscaling"
 	"github.com/heartbeatsjp/happo-agent/db"
 	"github.com/heartbeatsjp/happo-agent/halib"
 	"github.com/martini-contrib/binding"
@@ -166,6 +164,7 @@ func TestProxy1(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -210,6 +209,7 @@ func TestProxy2(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -260,6 +260,7 @@ func TestProxy3(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -304,6 +305,7 @@ func TestProxy4(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -356,6 +358,7 @@ func TestProxy5(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -403,6 +406,7 @@ func TestProxy6(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -450,6 +454,7 @@ func TestProxy7(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -497,6 +502,7 @@ func TestProxy8(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -544,6 +550,7 @@ func TestProxy9(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -583,6 +590,7 @@ func TestProxy10(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -626,6 +634,7 @@ func TestProxy11(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -669,6 +678,7 @@ func TestProxy12(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -712,6 +722,7 @@ func TestProxy13(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -783,6 +794,7 @@ func TestProxy14(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -854,6 +866,7 @@ func TestProxy15(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	alias := "dummy-prod-ag-dummy-prod-app-1"
 	port := 6777
@@ -906,6 +919,7 @@ func TestProxy16(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	//edge
 	ts := httptest.NewTLSServer(
@@ -951,6 +965,7 @@ func TestProxy17(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	requestJSON := fmt.Sprintf(`{
 		"proxy_hostport": ["%s:%d"],
@@ -981,6 +996,7 @@ func TestProxy18(t *testing.T) {
 	m := martini.Classic()
 	m.Use(render.Renderer())
 	m.Post("/proxy", binding.Json(halib.ProxyRequest{}), Proxy)
+	m.Map(&autoscaling.AWSClient{})
 
 	alias := "dummy-prod-ag-dummy-prod-app-1"
 	port := 6777

--- a/model/status.go
+++ b/model/status.go
@@ -92,14 +92,13 @@ func MemoryStatus(req *http.Request, r render.Render) {
 }
 
 // AutoScalingStatus implements /status/autoscaling endpoint
-func AutoScalingStatus(req *http.Request, r render.Render) {
+func AutoScalingStatus(req *http.Request, r render.Render, client *autoscaling.AWSClient) {
 	config, err := autoscaling.GetAutoScalingConfig(AutoScalingConfigFile)
 	if err != nil {
 		r.JSON(http.StatusInternalServerError, halib.AutoScalingStatus{})
 		return
 	}
 
-	client := autoscaling.NewAWSClient()
 	var status []halib.AutoScalingStatus
 	for _, a := range config.AutoScalings {
 		diff, err := autoscaling.CompareInstances(client, a.AutoScalingGroupName, a.HostPrefix)


### PR DESCRIPTION
Fix issue that region config for AWS client was hardcode to `ap-northeast-1`. And some refactor.

Fix
- Region config fetches by EC2 metadata and that set when creating AWS client.

Refactor
- Create AWS client at initializing daemon, and pass to the handler with [service injection](https://github.com/go-martini/martini/tree/v1.0#service-injection) (to avoid redundant code by error handling in each handle functions).
