### PR TITLE
Improve handling errors from client management server

### DIFF
--- a/command/add.go
+++ b/command/add.go
@@ -3,6 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/codegangsta/cli"
@@ -33,7 +34,11 @@ func CmdAdd(c *cli.Context) error {
 	if resp.StatusCode == http.StatusFound {
 		return cli.NewExitError("Conflict!", 1)
 	} else if resp.StatusCode != http.StatusOK {
-		return cli.NewExitError("Failed!", 1)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			cli.NewExitError(fmt.Sprintf("Failed! [%d] (response body cannot be read)", resp.StatusCode), 1)
+		}
+		return cli.NewExitError(fmt.Sprintf("Failed! [%d] %s", resp.StatusCode, body), 1)
 	}
 	fmt.Println("Success.")
 	return nil

--- a/command/add_test.go
+++ b/command/add_test.go
@@ -64,14 +64,7 @@ func TestCmdAdd(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			app := cli.NewApp()
-			set := flag.NewFlagSet("test", 0)
-			set.String("endpoint", c.endpoint, "")
-			set.String("group_name", c.group, "")
-			set.String("ip", c.ip, "")
-			mockCLI := cli.NewContext(app, set, nil)
-			mockCLI.Command.Name = "add"
-
+			mockCLI := buildBasicContext("add", c.endpoint, c.group, c.ip)
 			if err := CmdAdd(mockCLI); err != nil {
 				if c.isNormalTest {
 					assert.Nil(t, err)
@@ -102,7 +95,7 @@ func TestCmdAdd_AutoScaling(t *testing.T) {
 		isNormalTest         bool
 	}{
 		{
-			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \
+			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \ 
 							--autoscaling_group_name hb-autoscaling --autoscaling_count 10 --host_prefix app`,
 			endpoint:             ts.URL,
 			group:                "HB_TEST",
@@ -114,7 +107,7 @@ func TestCmdAdd_AutoScaling(t *testing.T) {
 			isNormalTest:         true,
 		},
 		{
-			name: `happo-agent add_ag --endpoint <endpoint url> --proxy 192.0.2.1 \
+			name: `happo-agent add_ag --endpoint <endpoint url> --proxy 192.0.2.1 \ 
 							--autoscaling_group_name hb-autoscaling --autoscaling_count 10 --host_prefix app`,
 			endpoint:             ts.URL,
 			group:                "",
@@ -126,7 +119,7 @@ func TestCmdAdd_AutoScaling(t *testing.T) {
 			isNormalTest:         false,
 		},
 		{
-			name: `happo-agent add_ag --endpoint <endpoint url>  --group_name HB_TEST \
+			name: `happo-agent add_ag --endpoint <endpoint url>  --group_name HB_TEST \ 
 							--autoscaling_group_name hb-autoscaling --autoscaling_count 10 --host_prefix app`,
 			endpoint:             ts.URL,
 			group:                "HB_TEST",
@@ -138,7 +131,7 @@ func TestCmdAdd_AutoScaling(t *testing.T) {
 			isNormalTest:         false,
 		},
 		{
-			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \
+			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \ 
 							--autoscaling_count 10 --host_prefix app`,
 			endpoint:             ts.URL,
 			group:                "HB_TEST",
@@ -150,7 +143,7 @@ func TestCmdAdd_AutoScaling(t *testing.T) {
 			isNormalTest:         false,
 		},
 		{
-			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \
+			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \ 
 							--autoscaling_group_name hb-autoscaling --host_prefix app`,
 			endpoint:             ts.URL,
 			group:                "HB_TEST",
@@ -162,7 +155,7 @@ func TestCmdAdd_AutoScaling(t *testing.T) {
 			isNormalTest:         false,
 		},
 		{
-			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \
+			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \ 
 							--autoscaling_group_name hb-autoscaling --autoscaling_count -5 --host_prefix app`,
 			endpoint:             ts.URL,
 			group:                "HB_TEST",
@@ -174,7 +167,7 @@ func TestCmdAdd_AutoScaling(t *testing.T) {
 			isNormalTest:         false,
 		},
 		{
-			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \
+			name: `happo-agent add_ag --endpoint <endpoint url> --group_name HB_TEST --proxy 192.0.2.1 \ 
 							--autoscaling_group_name hb-autoscaling --autoscaling_count 10`,
 			endpoint:             ts.URL,
 			group:                "HB_TEST",
@@ -227,14 +220,7 @@ func TestCmdAddError(t *testing.T) {
 					}))
 			defer ts.Close()
 
-			app := cli.NewApp()
-			set := flag.NewFlagSet("test", 0)
-			set.String("endpoint", ts.URL, "")
-			set.String("group_name", "TEST", "")
-			set.String("ip", "192.168.0.1", "")
-			mockCLI := cli.NewContext(app, set, nil)
-			mockCLI.Command.Name = "add"
-
+			mockCLI := buildBasicContext("add", ts.URL, "TEST", "192.168.0.1")
 			err := CmdAdd(mockCLI)
 			assert.NotNil(t, err)
 			assert.EqualError(t, err, fmt.Sprintf("Failed! [%d] dummy message", status))

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -1,0 +1,18 @@
+package command
+
+import (
+	"flag"
+
+	"github.com/codegangsta/cli"
+)
+
+func buildBasicContext(command, endpoint, groupname, ip string) *cli.Context {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	set.String("endpoint", endpoint, "")
+	set.String("group_name", groupname, "")
+	set.String("ip", ip, "")
+	mockCLI := cli.NewContext(app, set, nil)
+	mockCLI.Command.Name = command
+	return mockCLI
+}

--- a/command/is_added.go
+++ b/command/is_added.go
@@ -34,6 +34,7 @@ func CmdIsAdded(c *cli.Context) error {
 		return nil
 	} else {
 		body, err := ioutil.ReadAll(resp.Body)
+		// exit with code 2 as older version did so
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("Failed! [%d] (response body cannot be read)", resp.StatusCode), 2)
 		}

--- a/command/is_added.go
+++ b/command/is_added.go
@@ -35,7 +35,7 @@ func CmdIsAdded(c *cli.Context) error {
 	} else {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			cli.NewExitError(fmt.Sprintf("Failed! [%d] (response body cannot be read)", resp.StatusCode), 2)
+			return cli.NewExitError(fmt.Sprintf("Failed! [%d] (response body cannot be read)", resp.StatusCode), 2)
 		}
 		return cli.NewExitError(fmt.Sprintf("Failed! [%d] %s", resp.StatusCode, body), 2)
 	}

--- a/command/is_added.go
+++ b/command/is_added.go
@@ -3,6 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/codegangsta/cli"
@@ -31,6 +32,11 @@ func CmdIsAdded(c *cli.Context) error {
 	} else if resp.StatusCode == http.StatusFound {
 		fmt.Println("Found.")
 		return nil
+	} else {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			cli.NewExitError(fmt.Sprintf("Failed! [%d] (response body cannot be read)", resp.StatusCode), 2)
+		}
+		return cli.NewExitError(fmt.Sprintf("Failed! [%d] %s", resp.StatusCode, body), 2)
 	}
-	return cli.NewExitError("Unknown Status", 2)
 }

--- a/command/is_added_test.go
+++ b/command/is_added_test.go
@@ -1,7 +1,75 @@
 package command
 
-import "testing"
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
 
-func TestCmdIs_added(t *testing.T) {
-	// Write your code here
+	"github.com/codegangsta/cli"
+	"github.com/stretchr/testify/assert"
+)
+
+func buildContext(command, endpoint, groupname, ip string) *cli.Context {
+	app := cli.NewApp()
+	set := flag.NewFlagSet("test", 0)
+	set.String("endpoint", endpoint, "")
+	set.String("group_name", groupname, "")
+	set.String("ip", ip, "")
+	mockCLI := cli.NewContext(app, set, nil)
+	mockCLI.Command.Name = command
+	return mockCLI
+}
+
+func TestCmdIsAddedFound(t *testing.T) {
+	ts := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusFound)
+			}))
+	defer ts.Close()
+
+	mockCLI := buildContext("is_added", ts.URL, "TEST", "192.168.0.1")
+	err := CmdIsAdded(mockCLI)
+	assert.Nil(t, err)
+}
+
+func TestCmdIsAddedNotFound(t *testing.T) {
+	ts := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+	defer ts.Close()
+
+	mockCLI := buildContext("is_added", ts.URL, "TEST", "192.168.0.1")
+	err := CmdIsAdded(mockCLI)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "Not found.")
+}
+
+func TestCmdIsAddedError(t *testing.T) {
+	statuses := []int{
+		http.StatusBadRequest,
+		http.StatusInternalServerError,
+	}
+
+	for _, status := range statuses {
+		t.Run("status_"+strconv.Itoa(status), func(t *testing.T) {
+			ts := httptest.NewServer(
+				http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(status)
+						w.Write([]byte("dummy message"))
+					}))
+			defer ts.Close()
+
+			mockCLI := buildContext("is_added", ts.URL, "TEST", "192.168.0.1")
+			err := CmdIsAdded(mockCLI)
+			assert.NotNil(t, err)
+			assert.EqualError(t, err, fmt.Sprintf("Failed! [%d] dummy message", status))
+		})
+	}
 }

--- a/command/is_added_test.go
+++ b/command/is_added_test.go
@@ -1,27 +1,14 @@
 package command
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 
-	"github.com/codegangsta/cli"
 	"github.com/stretchr/testify/assert"
 )
-
-func buildContext(command, endpoint, groupname, ip string) *cli.Context {
-	app := cli.NewApp()
-	set := flag.NewFlagSet("test", 0)
-	set.String("endpoint", endpoint, "")
-	set.String("group_name", groupname, "")
-	set.String("ip", ip, "")
-	mockCLI := cli.NewContext(app, set, nil)
-	mockCLI.Command.Name = command
-	return mockCLI
-}
 
 func TestCmdIsAddedFound(t *testing.T) {
 	ts := httptest.NewServer(
@@ -31,7 +18,7 @@ func TestCmdIsAddedFound(t *testing.T) {
 			}))
 	defer ts.Close()
 
-	mockCLI := buildContext("is_added", ts.URL, "TEST", "192.168.0.1")
+	mockCLI := buildBasicContext("is_added", ts.URL, "TEST", "192.168.0.1")
 	err := CmdIsAdded(mockCLI)
 	assert.Nil(t, err)
 }
@@ -44,7 +31,7 @@ func TestCmdIsAddedNotFound(t *testing.T) {
 			}))
 	defer ts.Close()
 
-	mockCLI := buildContext("is_added", ts.URL, "TEST", "192.168.0.1")
+	mockCLI := buildBasicContext("is_added", ts.URL, "TEST", "192.168.0.1")
 	err := CmdIsAdded(mockCLI)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "Not found.")
@@ -66,7 +53,7 @@ func TestCmdIsAddedError(t *testing.T) {
 					}))
 			defer ts.Close()
 
-			mockCLI := buildContext("is_added", ts.URL, "TEST", "192.168.0.1")
+			mockCLI := buildBasicContext("is_added", ts.URL, "TEST", "192.168.0.1")
 			err := CmdIsAdded(mockCLI)
 			assert.NotNil(t, err)
 			assert.EqualError(t, err, fmt.Sprintf("Failed! [%d] dummy message", status))

--- a/command/is_added_test.go
+++ b/command/is_added_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/codegangsta/cli"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,9 +55,10 @@ func TestCmdIsAddedError(t *testing.T) {
 			defer ts.Close()
 
 			mockCLI := buildBasicContext("is_added", ts.URL, "TEST", "192.168.0.1")
-			err := CmdIsAdded(mockCLI)
+			err := CmdIsAdded(mockCLI).(*cli.ExitError)
 			assert.NotNil(t, err)
 			assert.EqualError(t, err, fmt.Sprintf("Failed! [%d] dummy message", status))
+			assert.Equal(t, 2, err.ExitCode())
 		})
 	}
 }

--- a/command/remove.go
+++ b/command/remove.go
@@ -3,6 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/codegangsta/cli"
@@ -29,7 +30,11 @@ func CmdRemove(c *cli.Context) error {
 	if resp.StatusCode == http.StatusNotFound {
 		return cli.NewExitError("Not found.", 1)
 	} else if resp.StatusCode != http.StatusOK {
-		return cli.NewExitError("Failed!", 1)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			cli.NewExitError(fmt.Sprintf("Failed! [%d] (response body cannot be read)", resp.StatusCode), 1)
+		}
+		return cli.NewExitError(fmt.Sprintf("Failed! [%d] %s", resp.StatusCode, body), 1)
 	}
 	fmt.Println("Success.")
 	return nil

--- a/command/remove_test.go
+++ b/command/remove_test.go
@@ -1,13 +1,11 @@
 package command
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/codegangsta/cli"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +36,7 @@ func TestCmdRemove(t *testing.T) {
 			resStatusCode: http.StatusInternalServerError,
 			resBody:       `{"status":"NG","message":"some error has occured!!"}`,
 			isNormalTest:  false,
-			expected:      "Failed! [500] {\"status\":\"NG\",\"message\":\"some error has occured!!\"}\n",
+			expected:      `Failed! [500] {"status":"NG","message":"some error has occured!!"}` + "\n",
 		},
 	}
 
@@ -54,14 +52,7 @@ func TestCmdRemove(t *testing.T) {
 					}))
 			defer ts.Close()
 
-			app := cli.NewApp()
-			set := flag.NewFlagSet("test", 0)
-			set.String("endpoint", ts.URL, "")
-			set.String("group_name", dummyGroupName, "")
-			set.String("ip", dummyIP, "")
-			mockCLI := cli.NewContext(app, set, nil)
-			mockCLI.Command.Name = "remove"
-
+			mockCLI := buildBasicContext("remove", ts.URL, dummyGroupName, dummyIP)
 			if err := CmdRemove(mockCLI); err != nil {
 				if c.isNormalTest {
 					assert.Nil(t, err)

--- a/command/remove_test.go
+++ b/command/remove_test.go
@@ -38,7 +38,7 @@ func TestCmdRemove(t *testing.T) {
 			resStatusCode: http.StatusInternalServerError,
 			resBody:       `{"status":"NG","message":"some error has occured!!"}`,
 			isNormalTest:  false,
-			expected:      "Failed!",
+			expected:      "Failed! [500] {\"status\":\"NG\",\"message\":\"some error has occured!!\"}\n",
 		},
 	}
 


### PR DESCRIPTION
Current version of happo-agent prints only `Failed!` or `Unknown Status` when a client management server returns some error message. 
I think it would be helpful for the message to be displayed thus have implemented that.