### PR TITLE
Fix client side validation

### DIFF
--- a/command/is_added.go
+++ b/command/is_added.go
@@ -18,6 +18,10 @@ func CmdIsAdded(c *cli.Context) error {
 	}
 
 	manageRequest, err := util.BindManageParameter(c)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
 	data, err := json.Marshal(manageRequest)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)

--- a/command/is_added_test.go
+++ b/command/is_added_test.go
@@ -62,3 +62,36 @@ func TestCmdIsAddedError(t *testing.T) {
 		})
 	}
 }
+
+func TestCmdIsAddedValidation(t *testing.T) {
+	cases := []struct {
+		caseName    string
+		group       string
+		ip          string
+		expectedMsg string
+	}{
+		{
+			caseName:    "blank group",
+			group:       "",
+			ip:          "192.168.0.1",
+			expectedMsg: "group_name is null",
+		},
+		{
+			caseName:    "blank ip",
+			group:       "TEST",
+			ip:          "",
+			expectedMsg: "ip is null",
+		},
+	}
+
+	dummyEndpoint := "http://localhost:6776"
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			mockCLI := buildBasicContext("is_added", dummyEndpoint, c.group, c.ip)
+			err := CmdIsAdded(mockCLI).(*cli.ExitError)
+			assert.NotNil(t, err)
+			assert.Equal(t, 1, err.ExitCode())
+			assert.EqualError(t, err, c.expectedMsg)
+		})
+	}
+}

--- a/command/remove.go
+++ b/command/remove.go
@@ -18,6 +18,9 @@ func CmdRemove(c *cli.Context) error {
 	}
 
 	manageRequest, err := util.BindManageParameter(c)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
 	data, err := json.Marshal(manageRequest)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)

--- a/command/remove_test.go
+++ b/command/remove_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/codegangsta/cli"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,6 +61,39 @@ func TestCmdRemove(t *testing.T) {
 					assert.EqualError(t, err, c.expected)
 				}
 			}
+		})
+	}
+}
+
+func TestCmdRemoveValidation(t *testing.T) {
+	cases := []struct {
+		caseName    string
+		group       string
+		ip          string
+		expectedMsg string
+	}{
+		{
+			caseName:    "blank group",
+			group:       "",
+			ip:          "192.168.0.1",
+			expectedMsg: "group_name is null",
+		},
+		{
+			caseName:    "blank ip",
+			group:       "TEST",
+			ip:          "",
+			expectedMsg: "ip is null",
+		},
+	}
+
+	dummyEndpoint := "http://localhost:6776"
+	for _, c := range cases {
+		t.Run(c.caseName, func(t *testing.T) {
+			mockCLI := buildBasicContext("remove", dummyEndpoint, c.group, c.ip)
+			err := CmdRemove(mockCLI).(*cli.ExitError)
+			assert.NotNil(t, err)
+			assert.Equal(t, 1, err.ExitCode())
+			assert.EqualError(t, err, c.expectedMsg)
 		})
 	}
 }


### PR DESCRIPTION
Current version of happo-agent does client-side validation before request to management server but the result is not fully handled. This let happo-agent send empty request to the server.

This PR adds some handlers not to ignore those validation errors.