### PR TITLE
Fix readme

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -286,14 +286,17 @@ OK
     - proxy_hostport:
         - (配列) 踏み台サーバのIP:Port 多段可能
     - request_type: どのURIを実行するか
-    - request_json: 監視対象サーバに届けるJSON
+    - request_json: 監視対象サーバに送信するJSONをBase64エンコードした文字列
 - 返り値の形式
     - JSON
 - 返り値の変数
     - 実行したURLのレスポンスに従います
 
 ```
-$ wget -q --no-check-certificate -O - https://192.0.2.1:6777/proxy --post-data='{"proxy_hostport": ["198.51.100.1:6777"], "request_type": "monitor", "request_json": "{\"apikey\": \"\", \"plugin_name\": \"check_procs\", \"plugin_option\": \"-w 100 -c 200\"}"}'
+$ echo -n '{"apikey":"","plugin_name":"check_procs","plugin_option":"-w 100 -c 200"}' | base64
+eyJhcGlrZXkiOiIiLCJwbHVnaW5fbmFtZSI6ImNoZWNrX3Byb2NzIiwicGx1Z2luX29wdGlvbiI6Ii13IDEwMCAtYyAyMDAifQ==
+
+$ wget -q --no-check-certificate -O - https://192.0.2.1:6777/proxy --post-data='{"proxy_hostport": ["198.51.100.1:6777"], "request_type": "monitor", "request_json": "eyJhcGlrZXkiOiIiLCJwbHVnaW5fbmFtZSI6ImNoZWNrX3Byb2NzIiwicGx1Z2luX29wdGlvbiI6Ii13IDEwMCAtYyAyMDAifQ=="}'
 {"return_value":1,"message":"PROCS WARNING: 168 processes\n"}
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -86,7 +86,7 @@ $ sudo yum install epel-release
 $ sudo yum install nagios-plugins-all
 $ go get -dv github.com/heartbeatsjp/happo-agent
 $ cd $GOHOME/src/bin
-$ openssl genrsa -aes128 -out happo-agent.key 2048
+$ openssl genrsa -out happo-agent.key 2048
 $ openssl req -new -key happo-agent.key -sha256 -out happo.csr
 $ openssl x509 -in happo-agent.csr -days 3650 -req -signkey happo.key -sha256 -out happo.pub
 $ touch metrics.yaml

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ go get -dv github.com/heartbeatsjp/happo-agent
 $ sudo install $GOHOME/src/bin/happo-agent /usr/local/bin/happo-agent
 $ sudo install -d -m 755 /etc/happo
 $ cd /etc/happo
-$ sudo openssl genrsa -aes128 -out happo-agent.key 2048
+$ sudo openssl genrsa -out happo-agent.key 2048
 $ sudo openssl req -new -key happo-agent.key -sha256 -out happo-agent.csr
 $ sudo openssl x509 -in happo-agent.csr -days 3650 -req -signkey happo-agent.key -sha256 -out happo-agent.pub
 $ sudo touch metrics.yaml

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Use agent bastion(proxy) mode.
     - proxy\_hostport:
         - (Array) bastion_ip:port. It can multiple define.
     - request\_type: request type (e.g. `monitor`)
-    - request\_json: Send JSON string to server.
+    - request\_json: Base64 encoded JSON string to be sent to destination host.
 - Return format
     - JSON
 - Return variables
@@ -292,7 +292,10 @@ If destination host is AutoScaling instance, it will behave as follows.
         - dummy response: `{"return_value":0,"message":"<alias> has not been assigned Instance\n"}`
 
 ```
-$ wget -q --no-check-certificate -O - https://192.0.2.1:6777/proxy --post-data='{"proxy_hostport": ["198.51.100.1:6777"], "request_type": "monitor", "request_json": "{\"apikey\": \"\", \"plugin_name\": \"check_procs\", \"plugin_option\": \"-w 100 -c 200\"}"}'
+$ echo -n '{"apikey":"","plugin_name":"check_procs","plugin_option":"-w 100 -c 200"}' | base64
+eyJhcGlrZXkiOiIiLCJwbHVnaW5fbmFtZSI6ImNoZWNrX3Byb2NzIiwicGx1Z2luX29wdGlvbiI6Ii13IDEwMCAtYyAyMDAifQ==
+
+$ wget -q --no-check-certificate -O - https://192.0.2.1:6777/proxy --post-data='{"proxy_hostport": ["198.51.100.1:6777"], "request_type": "monitor", "request_json": "eyJhcGlrZXkiOiIiLCJwbHVnaW5fbmFtZSI6ImNoZWNrX3Byb2NzIiwicGx1Z2luX29wdGlvbiI6Ii13IDEwMCAtYyAyMDAifQ=="}'
 {"return_value":1,"message":"PROCS WARNING: 168 processes\n"}
 ```
 


### PR DESCRIPTION
I think following two parts of the README are incorrect.

- happo-agent does not actually support certificate using encrypted key.
- `request_json` parameter for `/proxy` request should not be a plaintext but base64 encoded JSON.

This PR fixes them.