### PR TITLE
Update golang version(1.9.4 -> 1.13)

### DIFF
--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -811,7 +811,7 @@ func TestJoinAutoScalingGroup1(t *testing.T) {
 		isNormalTest           bool
 	}{
 		{
-			name: "default",
+			name:                   "default",
 			ec2MetaDataisAvailable: true,
 			ec2MetaDatahasError:    false,
 			statusCode:             http.StatusOK,
@@ -841,7 +841,7 @@ func TestJoinAutoScalingGroup1(t *testing.T) {
 			isNormalTest: true,
 		},
 		{
-			name: "error response",
+			name:                   "error response",
 			ec2MetaDataisAvailable: true,
 			ec2MetaDatahasError:    false,
 			statusCode:             http.StatusInternalServerError,
@@ -850,7 +850,7 @@ func TestJoinAutoScalingGroup1(t *testing.T) {
 			isNormalTest:           false,
 		},
 		{
-			name: "ec2metadata is not available",
+			name:                   "ec2metadata is not available",
 			ec2MetaDataisAvailable: false,
 			ec2MetaDatahasError:    false,
 			dummyResponse:          statusErrorResponse,
@@ -858,7 +858,7 @@ func TestJoinAutoScalingGroup1(t *testing.T) {
 			isNormalTest:           false,
 		},
 		{
-			name: "ec2metadata has error",
+			name:                   "ec2metadata has error",
 			ec2MetaDataisAvailable: true,
 			ec2MetaDatahasError:    true,
 			dummyResponse:          statusErrorResponse,
@@ -925,7 +925,7 @@ func TestLeaveAutoScalingGroup(t *testing.T) {
 		isNormalTest           bool
 	}{
 		{
-			name: "default",
+			name:                   "default",
 			ec2MetaDataisAvailable: true,
 			ec2MetaDatahasError:    false,
 			statusCode:             http.StatusOK,
@@ -933,7 +933,7 @@ func TestLeaveAutoScalingGroup(t *testing.T) {
 			isNormalTest:           true,
 		},
 		{
-			name: "error response",
+			name:                   "error response",
 			ec2MetaDataisAvailable: true,
 			ec2MetaDatahasError:    false,
 			statusCode:             http.StatusInternalServerError,
@@ -941,14 +941,14 @@ func TestLeaveAutoScalingGroup(t *testing.T) {
 			isNormalTest:           false,
 		},
 		{
-			name: "ec2metadata is not available",
+			name:                   "ec2metadata is not available",
 			ec2MetaDataisAvailable: false,
 			ec2MetaDatahasError:    false,
 			dummyResponse:          statusErrorResponse,
 			isNormalTest:           false,
 		},
 		{
-			name: "ec2metadata has error",
+			name:                   "ec2metadata has error",
 			ec2MetaDataisAvailable: true,
 			ec2MetaDatahasError:    true,
 			dummyResponse:          statusErrorResponse,

--- a/collect/metrics.go
+++ b/collect/metrics.go
@@ -128,7 +128,7 @@ func SaveMetrics(now time.Time, metricsData []halib.MetricsData) error {
 		expired := []halib.MetricsData{}
 		dec := gob.NewDecoder(bytes.NewReader(value))
 		dec.Decode(&expired)
-		log.Warn("retire old metrics: key=%v(%v), value=%v\n", string(key), time.Unix(int64(unixTime), 0), expired)
+		log.Warn(fmt.Sprintf("retire old metrics: key=%v(%v), value=%v\n", string(key), time.Unix(int64(unixTime), 0), expired))
 	}
 	iter.Release()
 

--- a/model/monitor.go
+++ b/model/monitor.go
@@ -162,7 +162,7 @@ func saveMachineState() error {
 
 		// logging
 		unixTime, _ := strconv.Atoi(strings.SplitN(string(key), "-", 2)[1])
-		log.Warn("retire old metrics: key=%v(%v)\n", string(key), time.Unix(int64(unixTime), 0))
+		log.Warn(fmt.Sprintf("retire old metrics: key=%v(%v)\n", string(key), time.Unix(int64(unixTime), 0)))
 		// if write value to log, log become too large...
 	}
 	iter.Release()

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,9 +1,17 @@
-box: "netmarkjp/golang-build:1.9.4"
+box: "golang:1.13.3"
 command-timeout: 60
 build: 
   steps:
     - wercker/setup-go-workspace:
         package-dir: github.com/heartbeatsjp/happo-agent
+    - script: 
+        name: "go get module"
+        code: |
+            go get -u github.com/golang/dep/cmd/dep
+            go get -u golang.org/x/tools/cmd/goimports
+            go get -u github.com/mitchellh/gox
+            go get -u github.com/haya14busa/goverage       
+            go get -u golang.org/x/lint/golint
     - script:
         name: "install zip"
         code: sudo apt-get update -y && apt-get install -y zip

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,17 +1,9 @@
-box: "golang:1.13.3"
+box: "netmarkjp/golang-build:1.13"
 command-timeout: 60
 build: 
   steps:
     - wercker/setup-go-workspace:
         package-dir: github.com/heartbeatsjp/happo-agent
-    - script: 
-        name: "go get module"
-        code: |
-            go get -u github.com/golang/dep/cmd/dep
-            go get -u golang.org/x/tools/cmd/goimports
-            go get -u github.com/mitchellh/gox
-            go get -u github.com/haya14busa/goverage       
-            go get -u golang.org/x/lint/golint
     - script:
         name: "install zip"
         code: sudo apt-get update -y && apt-get install -y zip


### PR DESCRIPTION
Golang running on CI is old(golang:1.9.4).
Also, it is difficult to change the docker image being used. 

- Change the docker image used by wercker from netmarkjp/golang-build:1.9.4 to golang:1.13.3.
    - Add new step in wercker.yml(go get module)
- Fix go vet warning.
    - collect/metrics.go
    - model/monitor.go 

Please review.
